### PR TITLE
Add logout test

### DIFF
--- a/playwright/tests/login.spec.js
+++ b/playwright/tests/login.spec.js
@@ -15,13 +15,12 @@ async function fetchOtp(context) {
   return body.match(/\b(\d{6})\b/)[1];
 }
 
-test('login with OTP', async ({ page, context }) => {
+async function login(page, context) {
   await page.goto('https://xpendless-frontend-staging-d6pkpujjuq-ww.a.run.app/login');
   await page.getByLabel('Email address').fill('Ryan_Adams1@yopmail.com');
   await page.getByLabel('Password').fill('Xpendless@A1');
   await page.getByRole('button', { name: 'Login' }).click();
   await page.getByRole('textbox', { name: 'Please enter OTP character 1' }).waitFor();
-
 
   const otp = await fetchOtp(context);
   const digits = otp.split('');
@@ -29,6 +28,17 @@ test('login with OTP', async ({ page, context }) => {
     await page.getByRole('textbox', { name: `Please enter OTP character ${i + 1}` }).fill(digits[i]);
   }
   await page.getByRole('button', { name: 'Login' }).click();
-  await page.waitForURL('**/dashboard');
-  await expect(page.url()).toContain('/dashboard');
+  await page.getByRole('link', { name: /dashboard/i }).waitFor();
+  await expect(page.getByRole('link', { name: /dashboard/i })).toBeVisible();
+}
+
+test('login with OTP', async ({ page, context }) => {
+  await login(page, context);
+});
+
+test('logout via icon', async ({ page, context }) => {
+  await login(page, context);
+  await page.locator('a.nav-link').last().click();
+  await page.getByLabel('Email address').waitFor();
+  await expect(page.getByLabel('Email address')).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- add reusable `login` helper for OTP flow
- assert landing on dashboard by nav link text
- test logout by clicking nav link icon
- assert login page by presence of Email label instead of URL

## Testing
- `npm install`
- `npx playwright install chromium`
- `PLAYWRIGHT_BROWSERS_PATH=0 npx playwright install chromium`
- `PLAYWRIGHT_BROWSERS_PATH=0 npm test` *(fails: Test was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6844f05658488327ac7ec05400341597