### PR TITLE
Fix logout click issue

### DIFF
--- a/playwright/tests/login.spec.js
+++ b/playwright/tests/login.spec.js
@@ -38,7 +38,7 @@ test('login with OTP', async ({ page, context }) => {
 
 test('logout via icon', async ({ page, context }) => {
   await login(page, context);
-  await page.locator('a.nav-link').last().click();
+  await page.getByRole('link', { name: /logout/i }).click({ force: true });
   await page.getByLabel('Email address').waitFor();
   await expect(page.getByLabel('Email address')).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- refine logout selector in Playwright test to force click the logout link

## Testing
- `npx playwright test` *(fails: waiting for OTP inbox on yopmail)*

------
https://chatgpt.com/codex/tasks/task_e_6844f8237b9083279a060f043e35cf0f