### PR TITLE
Fix logout test by opening nav menu first

### DIFF
--- a/playwright/tests/login.spec.js
+++ b/playwright/tests/login.spec.js
@@ -38,6 +38,11 @@ test('login with OTP', async ({ page, context }) => {
 
 test('logout via icon', async ({ page, context }) => {
   await login(page, context);
+  // open the navigation menu first so that the logout link becomes clickable
+  const menuButton = page.locator('button.navbar-toggler');
+  if (await menuButton.isVisible()) {
+    await menuButton.click();
+  }
   await page.locator('a.nav-link').last().click();
   await page.getByLabel('Email address').waitFor();
   await expect(page.getByLabel('Email address')).toBeVisible();


### PR DESCRIPTION
## Summary
- open the navigation menu before clicking the last nav link during logout

## Testing
- `npm test` *(fails: unable to fetch OTP from yopmail)*

------
https://chatgpt.com/codex/tasks/task_e_6844f8237b9083279a060f043e35cf0f