### PR TITLE
Fix logout test by opening nav when hidden

### DIFF
--- a/playwright/tests/login.spec.js
+++ b/playwright/tests/login.spec.js
@@ -38,7 +38,11 @@ test('login with OTP', async ({ page, context }) => {
 
 test('logout via icon', async ({ page, context }) => {
   await login(page, context);
-  await page.locator('a.nav-link').last().click();
+  const logoutLink = page.getByRole('link', { name: /logout/i });
+  if (!(await logoutLink.isVisible())) {
+    await page.locator('button.navbar-toggler').click();
+  }
+  await logoutLink.click({ force: true });
   await page.getByLabel('Email address').waitFor();
   await expect(page.getByLabel('Email address')).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- ensure the logout link is visible by opening the navigation menu when required

## Testing
- `npm test` *(fails: page.waitForTimeout -> Test interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6844f8237b9083279a060f043e35cf0f