### PR TITLE
Fix phone and password values

### DIFF
--- a/playwright/tests/company-registration.spec.js
+++ b/playwright/tests/company-registration.spec.js
@@ -8,51 +8,87 @@ function randomEmail() {
 }
 
 function randomPhone() {
-  return `080${Math.floor(10000000 + Math.random() * 9000000)}`;
+  // Return a 9-digit phone number
+  return `${Math.floor(100000000 + Math.random() * 900000000)}`;
+}
 
+function randomAlpha(length = 6) {
+  const letters = 'abcdefghijklmnopqrstuvwxyz';
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += letters.charAt(Math.floor(Math.random() * letters.length));
+  }
+  return result;
 }
 
 // Test: company registration flow
-// - fills the registration form with random data
-// - confirms the mobile OTP using static code '123456'
-// - selects the first available subscription package
-// - skips optional onboarding screens
-// - verifies that dashboard is shown after registration
+// Steps reflect the current signup process:
+// 1. Enter admin details (first name, last name, email)
+// 2. Retrieve the email verification OTP from Yopmail
+// 3. Provide mobile number
+// 4. Confirm the mobile OTP using static code '123456'
+// 5. Set password and confirm password
+// 6. Enter business information
+// 7. Choose the first subscription package and skip onboarding
+// 8. Verify that the dashboard is displayed
 
-test('create company account', async ({ page }) => {
+test('create company account', async ({ page, context }) => {
   const email = randomEmail();
 
   const randomSuffix = Date.now().toString().slice(-4);
   const companyName = `Test Company ${randomSuffix}`;
-  const adminFirst = `Admin${randomSuffix}`;
-  const adminLast = `User${randomSuffix}`;
+  const adminFirst = `Admin${randomAlpha(5)}`;
+  const adminLast = `User${randomAlpha(5)}`;
   const mobile = randomPhone();
-  const password = 'Password@123';
+  const password = 'xpendless@A1';
 
   // Navigate to landing page and start registration flow
   await page.goto('https://xpendless-frontend-staging-d6pkpujjuq-ww.a.run.app/');
   await page.getByRole('link', { name: /create account for your company/i }).click();
 
+  // Step 1: admin details
+  await page.getByLabel(/first name/i).fill(adminFirst);
+  await page.getByLabel(/last name/i).fill(adminLast);
+  await page.getByLabel(/email address/i).fill(email);
+  await page.getByRole('button', { name: /continue/i }).click();
 
-  // Fill company details
-  await page.getByLabel(/business name/i).fill(companyName);
-  await page.getByLabel(/admin first name/i).fill(adminFirst);
-  await page.getByLabel(/admin last name/i).fill(adminLast);
-  await page.getByLabel(/admin email/i).fill(email);
+  // Step 2: verify email via OTP retrieved from Yopmail
+  await page.getByRole('textbox', { name: 'Please enter OTP character 1' }).waitFor();
+  const inbox = email.split('@')[0];
+  const mail = await context.newPage();
+  await mail.waitForTimeout(5000);
+  await mail.goto(`https://yopmail.com/?${inbox}`);
+  const inboxFrame = mail.frameLocator('#ifinbox');
+  await inboxFrame.locator('div.m').first().click();
+  const mailFrame = mail.frameLocator('#ifmail');
+  const body = await mailFrame.locator('body').innerText();
+  await mail.close();
+  const otpEmail = body.match(/\b(\d{6})\b/)[1];
+  for (let i = 0; i < otpEmail.length; i++) {
+    await page.getByRole('textbox', { name: `Please enter OTP character ${i + 1}` }).fill(otpEmail[i]);
+  }
+  await page.getByRole('button', { name: /continue|verify|confirm/i }).click();
+
+  // Step 3: mobile number
   await page.getByLabel(/mobile number/i).fill(mobile);
-  await page.getByLabel(/password/i).fill(password);
-  await page.getByLabel(/confirm password/i).fill(password);
+  await page.getByRole('button', { name: /continue|next/i }).click();
 
-  // Submit the registration form
-  await page.getByRole('button', { name: /create account/i }).click();
-
-  // Confirm OTP with static value
+  // Step 4: confirm mobile OTP with static value
   await page.getByRole('textbox', { name: 'Please enter OTP character 1' }).waitFor();
   const otpDigits = '123456'.split('');
   for (let i = 0; i < otpDigits.length; i++) {
     await page.getByRole('textbox', { name: `Please enter OTP character ${i + 1}` }).fill(otpDigits[i]);
   }
   await page.getByRole('button', { name: /continue|confirm|verify/i }).click();
+
+  // Step 5: set password
+  await page.getByLabel(/password/i).fill(password);
+  await page.getByLabel(/confirm password/i).fill(password);
+  await page.getByRole('button', { name: /continue|create account/i }).click();
+
+  // Step 6: business information
+  await page.getByLabel(/business name/i).fill(companyName);
+  await page.getByRole('button', { name: /create account|continue/i }).click();
 
   // Choose the first subscription package
   await page.getByRole('button', { name: /select plan|subscribe/i }).first().click();


### PR DESCRIPTION
## Summary
- generate 9-digit phone numbers
- use `xpendless@A1` for signup password

## Testing
- `npm install`
- `npx playwright install`
- `npm test` *(fails: browser launch errors and test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68478d253c088327824ad9e35d69e922