### PR TITLE
Add environment config for Playwright tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ npm install
 npx playwright install
 ```
 
+The `playwright/.env` file controls which deployment the tests run against.
+Set `CURRENT_ENV` to `dev`, `staging`, or `production` to target the
+corresponding URL defined in the same file.
+
 ## Running Playwright Tests
 
 From the same `playwright` directory execute the test suite with:

--- a/playwright/.env
+++ b/playwright/.env
@@ -1,0 +1,4 @@
+CURRENT_ENV=staging
+STAGING_URL=https://xpendless-frontend-staging-d6pkpujjuq-ww.a.run.app
+DEV_URL=https://xpendless-frontend-dev-385254729743.me-central1.run.app
+PROD_URL=

--- a/playwright/package-lock.json
+++ b/playwright/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.52.0"
+        "@playwright/test": "^1.52.0",
+        "dotenv": "^16.5.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -26,6 +27,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/fsevents": {

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "@playwright/test": "^1.52.0"
+    "@playwright/test": "^1.52.0",
+    "dotenv": "^16.5.0"
   }
 }

--- a/playwright/playwright.config.js
+++ b/playwright/playwright.config.js
@@ -1,4 +1,15 @@
 const { defineConfig } = require('@playwright/test');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env') });
+
+const envUrls = {
+  dev: process.env.DEV_URL,
+  staging: process.env.STAGING_URL,
+  production: process.env.PROD_URL,
+};
+
+const currentEnv = process.env.CURRENT_ENV || 'staging';
+const baseURL = envUrls[currentEnv] || envUrls.staging;
 
 module.exports = defineConfig({
   testDir: './tests',
@@ -9,5 +20,6 @@ module.exports = defineConfig({
   use: {
     headless: true,
     ignoreHTTPSErrors: true,
+    baseURL,
   },
 });

--- a/playwright/tests/company-registration.spec.js
+++ b/playwright/tests/company-registration.spec.js
@@ -49,7 +49,7 @@ test('create company account', async ({ page, context }) => {
   const password = 'xpendless@A1';
 
   // Navigate to landing page and start registration flow
-  await page.goto('https://xpendless-frontend-staging-d6pkpujjuq-ww.a.run.app/');
+  await page.goto('/');
   await page.getByRole('link', { name: /create account for your company/i }).click();
 
   // Step 1: admin details

--- a/playwright/tests/login.spec.js
+++ b/playwright/tests/login.spec.js
@@ -22,7 +22,7 @@ async function fetchOtp(context) {
 // Log in to the application and wait until the dashboard is visible
 async function login(page, context) {
   // Navigate to the login page
-  await page.goto('https://xpendless-frontend-staging-d6pkpujjuq-ww.a.run.app/login');
+  await page.goto('/login');
 
   // Fill in credentials
   await page.getByLabel('Email address').fill('Ryan_Adams1@yopmail.com');

--- a/playwright/tests/pettycash.spec.js
+++ b/playwright/tests/pettycash.spec.js
@@ -16,7 +16,7 @@ async function fetchOtp(context) {
 
 // Perform login flow including fetching OTP from email
 async function login(page, context) {
-  await page.goto('https://xpendless-frontend-staging-d6pkpujjuq-ww.a.run.app/login');
+  await page.goto('/login');
   await page.getByLabel('Email address').fill('Ryan_Adams1@yopmail.com');
   await page.getByLabel('Password').fill('Xpendless@A1');
   await page.getByRole('button', { name: 'Login' }).click();

--- a/playwright/tests/wallet.spec.js
+++ b/playwright/tests/wallet.spec.js
@@ -16,7 +16,7 @@ async function fetchOtp(context) {
 
 // Perform login flow using OTP from email
 async function login(page, context) {
-  await page.goto('https://xpendless-frontend-staging-d6pkpujjuq-ww.a.run.app/login');
+  await page.goto('/login');
   await page.getByLabel('Email address').fill('Ryan_Adams1@yopmail.com');
   await page.getByLabel('Password').fill('Xpendless@A1');
   await page.getByRole('button', { name: 'Login' }).click();


### PR DESCRIPTION
## Summary
- make environment URLs configurable via `.env`
- use Playwright baseURL from env settings
- update specs to rely on baseURL
- add dotenv dependency
- document environment usage in README

## Testing
- `npm test` *(fails: wallet-company-wallet-withdraw-funds, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6847bad1a14083279c07fc7114ff0420