### PR TITLE
Enable env via npm argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,19 @@ npm install
 npx playwright install
 ```
 
-The `playwright/.env` file controls which deployment the tests run against.
-Set `CURRENT_ENV` to `dev`, `staging`, or `production` to target the
-corresponding URL defined in the same file.
+The `playwright/.env` file defines the base URLs for each deployment.
+When running the tests you choose which environment to target by passing the
+desired environment name to the `npm test` command:
+`npm test <dev|staging|production>`.
+The command uses a small wrapper script that sets the environment before
+invoking Playwright.
 
 ## Running Playwright Tests
 
 From the same `playwright` directory execute the test suite with:
 
 ```bash
-npm test
+npm test staging
 ```
 
 If you accidentally run `npm test` from the repository root you will see an

--- a/playwright/.env
+++ b/playwright/.env
@@ -1,4 +1,3 @@
-CURRENT_ENV=staging
 STAGING_URL=https://xpendless-frontend-staging-d6pkpujjuq-ww.a.run.app
 DEV_URL=https://xpendless-frontend-dev-385254729743.me-central1.run.app
 PROD_URL=

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "playwright test"
+    "test": "node run-tests.js"
   },
   "keywords": [],
   "author": "",

--- a/playwright/playwright.config.js
+++ b/playwright/playwright.config.js
@@ -8,7 +8,10 @@ const envUrls = {
   production: process.env.PROD_URL,
 };
 
-const currentEnv = process.env.CURRENT_ENV || 'staging';
+// The environment to run against is provided by the wrapper script `run-tests.js`
+// which sets `CURRENT_ENV`. For backwards compatibility we also read
+// `npm_config_env` when the script is invoked with `--env`.
+const currentEnv = process.env.CURRENT_ENV || process.env.npm_config_env || 'staging';
 const baseURL = envUrls[currentEnv] || envUrls.staging;
 
 module.exports = defineConfig({

--- a/playwright/run-tests.js
+++ b/playwright/run-tests.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+const { spawnSync } = require('child_process');
+const args = process.argv.slice(2);
+const envName = args[0];
+if (!envName) {
+  console.error('Usage: npm test <env> [playwright args]');
+  process.exit(1);
+}
+process.env.CURRENT_ENV = envName;
+const result = spawnSync('npx', ['playwright', 'test', ...args.slice(1)], {
+  stdio: 'inherit',
+  env: process.env,
+});
+process.exit(result.status);


### PR DESCRIPTION
## Summary
- support selecting environment via `npm test <env>` wrapper
- document environment selection

## Testing
- `npm test staging` *(fails: locator.click: Test ended)*

------
https://chatgpt.com/codex/tasks/task_e_6847be0788088327b76ecdc1c56f575d