### PR TITLE
Clarify how to set CURRENT_ENV on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,31 @@ npx playwright install
 The `playwright/.env` file defines the base URLs for each deployment.
 When running the tests you choose which environment to target by passing the
 desired environment name to the `npm test` command:
-`npm test <dev|staging|production>`.
+
+```bash
+npm test <dev|staging|production>
+```
+
 The command uses a small wrapper script that sets the environment before
-invoking Playwright.
+invoking Playwright. You can also set the `CURRENT_ENV` variable manually if
+you prefer to call `npx playwright` directly:
+
+* **Unix/macOS**
+  ```bash
+  CURRENT_ENV=staging npx playwright test
+  ```
+* **Windows PowerShell**
+  ```powershell
+  $env:CURRENT_ENV = "staging"
+  npx playwright test
+  ```
+* **Windows cmd.exe**
+  ```cmd
+  set CURRENT_ENV=staging && npx playwright test
+  ```
+
+Additional Playwright options such as `--headed` can be appended after the
+environment name when using `npm test`, e.g. `npm test staging -- --headed`.
 
 ## Running Playwright Tests
 


### PR DESCRIPTION
## Summary
- document Windows syntax for environment variables
- show how to pass additional Playwright options

## Testing
- `npm install`
- `npx playwright install`
- `npm test staging -- --reporter=list` *(fails: Test was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6847c7176f848327985b8a5f8ac611ff