### PR TITLE
Enhance test data generation

### DIFF
--- a/playwright/package-lock.json
+++ b/playwright/package-lock.json
@@ -9,8 +9,26 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@faker-js/faker": "^9.8.0",
         "@playwright/test": "^1.52.0",
         "dotenv": "^16.5.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.8.0.tgz",
+      "integrity": "sha512-U9wpuSrJC93jZBxx/Qq2wPjCuYISBueyVUGK7qqdmj7r/nxaxwW8AQDCLeRO7wZnjj94sh3p246cAYjUKuqgfg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@playwright/test": {

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
+    "@faker-js/faker": "^9.8.0",
     "@playwright/test": "^1.52.0",
     "dotenv": "^16.5.0"
   }

--- a/playwright/tests/company-registration.spec.js
+++ b/playwright/tests/company-registration.spec.js
@@ -1,24 +1,11 @@
 // Import Playwright test APIs
 const { test, expect } = require('@playwright/test');
+const { faker } = require('@faker-js/faker');
 
 // Helper functions to generate random test data
-function randomEmail() {
-  const random = Math.random().toString(36).substring(2, 10);
-  return `user_${random}@yopmail.com`;
-}
-
 function randomPhone() {
   // Return a 9-digit phone number
   return `${Math.floor(100000000 + Math.random() * 900000000)}`;
-}
-
-function randomAlpha(length = 6) {
-  const letters = 'abcdefghijklmnopqrstuvwxyz';
-  let result = '';
-  for (let i = 0; i < length; i++) {
-    result += letters.charAt(Math.floor(Math.random() * letters.length));
-  }
-  return result;
 }
 
 function randomRegistrationNumber() {
@@ -39,12 +26,10 @@ function randomRegistrationNumber() {
 
 
 test('create company account', async ({ page, context }) => {
-  const email = randomEmail();
-
-  const randomSuffix = Date.now().toString().slice(-4);
-  const companyName = `Test Company ${randomSuffix}`;
-  const adminFirst = `Admin${randomAlpha(5)}`;
-  const adminLast = `User${randomAlpha(5)}`;
+  const adminFirst = faker.person.firstName();
+  const adminLast = faker.person.lastName();
+  const email = `${adminFirst.toLowerCase()}${faker.number.int({ min: 100, max: 999 })}@yopmail.com`;
+  const companyName = `${adminFirst} Limited ${faker.number.int({ min: 100, max: 999 })}`;
   const mobile = randomPhone();
   const password = 'xpendless@A1';
 


### PR DESCRIPTION
## Summary
- use Faker for realistic names
- generate email and company names based on the first name
- update dependencies

## Testing
- `npm test staging tests/company-registration.spec.js -- --list`
- `npm test staging tests/company-registration.spec.js -- --workers=1` *(fails: browserType.launch executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_6848217b90d48327a36ca0abb1baae4e