### PR TITLE
Add Playwright reporting utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 venv/
 **/node_modules/
 playwright/test-results/
+playwright/report/

--- a/README.md
+++ b/README.md
@@ -66,3 +66,13 @@ If you accidentally run `npm test` from the repository root you will see an
 Reusable values such as login credentials and transaction amounts are defined in
 `playwright/testdata/index.js`. Tests and page objects import these constants so
 that data can be managed in a single location.
+
+## Test Reports
+
+Running the Playwright tests will automatically produce a JSON report in
+`playwright/report/report.json`. No extra command is required – the custom
+reporter is configured in `playwright.config.js` and runs every time you execute
+`npm test`. The report captures browser and environment information, the total
+time for the suite, and details for each test including duration, outcome and a
+path to its screenshot. Failed tests also include a short code snippet showing
+where the error occurred.

--- a/playwright/custom-reporter.js
+++ b/playwright/custom-reporter.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+
+class CustomReporter {
+  onBegin(config) {
+    this.results = [];
+    this.startTime = Date.now();
+    this.browser = config.projects[0].use.browserName || 'chromium';
+    this.environment = process.env.CURRENT_ENV || 'staging';
+  }
+
+  onTestEnd(test, result) {
+    const attachments = result.attachments || [];
+    const shot = attachments.find(a => a.name === 'screenshot');
+    const screenshot = shot ? path.relative(process.cwd(), shot.path) : undefined;
+    const info = {
+      id: test.id,
+      title: test.title,
+      outcome: result.status,
+      duration: result.duration,
+      description: test.title,
+      screenshot,
+    };
+
+    if (result.error) {
+      info.errorMessage = result.error.message;
+      const stack = result.error.stack || '';
+      const match = stack.match(/(\S+\.js):(\d+):(\d+)/);
+      if (match) {
+        const file = match[1];
+        const line = parseInt(match[2], 10);
+        info.failureLocation = { file: path.relative(process.cwd(), file), line };
+        try {
+          const lines = fs.readFileSync(file, 'utf-8').split('\n');
+          info.codeSnippet = lines.slice(Math.max(0, line - 2), line + 1).join('\n');
+        } catch (e) {
+          // ignore read errors
+        }
+      }
+    }
+
+    this.results.push(info);
+  }
+
+  onEnd() {
+    const totalTime = Date.now() - this.startTime;
+    const summary = this.results.reduce((acc, r) => {
+      acc[r.outcome] = (acc[r.outcome] || 0) + 1;
+      return acc;
+    }, {});
+
+    const byOutcome = this.results.reduce((acc, r) => {
+      if (!acc[r.outcome]) acc[r.outcome] = [];
+      acc[r.outcome].push(r);
+      return acc;
+    }, {});
+
+    const report = {
+      environment: this.environment,
+      browser: this.browser,
+      totalTime,
+      summary,
+      tests: this.results,
+      byOutcome,
+    };
+
+    const dir = path.join(__dirname, 'report');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'report.json');
+    fs.writeFileSync(file, JSON.stringify(report, null, 2));
+    console.log(`Custom report written to ${file}`);
+  }
+}
+
+module.exports = CustomReporter;

--- a/playwright/playwright.config.js
+++ b/playwright/playwright.config.js
@@ -20,6 +20,7 @@ module.exports = defineConfig({
   // <— run only one worker (i.e. serial execution)
   workers: 1,
   timeout: 2 * 60 * 1000,         // 2 minutes
+  reporter: [ ['list'], ['./custom-reporter.js'] ],
   use: {
     headless: true,
     ignoreHTTPSErrors: true,

--- a/playwright/test-hooks.js
+++ b/playwright/test-hooks.js
@@ -1,0 +1,19 @@
+const base = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const test = base.test;
+
+// Capture a screenshot at the end of every test
+// and attach it to the test results.
+test.afterEach(async ({ page }, testInfo) => {
+  if (!page) return;
+  const dir = path.join(__dirname, 'report', 'screenshots');
+  await fs.promises.mkdir(dir, { recursive: true });
+  const sanitized = testInfo.title.replace(/[^a-z0-9]+/gi, '_').toLowerCase();
+  const filePath = path.join(dir, `${sanitized}.png`);
+  await page.screenshot({ path: filePath, fullPage: true });
+  testInfo.attachments.push({ name: 'screenshot', path: filePath, contentType: 'image/png' });
+});
+
+module.exports = { test, expect: base.expect };

--- a/playwright/tests/company-registration.spec.js
+++ b/playwright/tests/company-registration.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../test-hooks');
 const { CompanyRegistrationPage } = require('../pages/company-registration-page');
 
 // This test covers the full company sign-up process

--- a/playwright/tests/login.spec.js
+++ b/playwright/tests/login.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../test-hooks');
 const { LoginPage } = require('../pages/login-page');
 const testData = require('../testdata');
 

--- a/playwright/tests/pettycash.spec.js
+++ b/playwright/tests/pettycash.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../test-hooks');
 const { LoginPage } = require('../pages/login-page');
 const { PettyCashPage } = require('../pages/petty-cash-page');
 const testData = require('../testdata');

--- a/playwright/tests/wallet.spec.js
+++ b/playwright/tests/wallet.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../test-hooks');
 const { LoginPage } = require('../pages/login-page');
 const { WalletPage } = require('../pages/wallet-page');
 const testData = require('../testdata');


### PR DESCRIPTION
## Summary
- capture screenshots after each Playwright test using a new hook
- generate a JSON report with environment, browser, times and failures
- activate the custom reporter in Playwright config
- update tests to use the new test wrapper
- ignore generated report artifacts
- document how reports are produced automatically
- group test results by outcome in the report

## Testing
- `npm install`
- `npx playwright install`
- `npm test dev -- --max-failures=1` *(fails: test timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68482e174594832780bb938b75d30df8