### PR TITLE
Fix Allure results path

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ that data can be managed in a single location.
    ```
 
    This populates `playwright/allure-results` with the data used by the report.
+   The reporter always writes to this folder so the command works even
+   when tests are started from another directory.
 
 2. **Generate the report** while still inside the `playwright` folder:
 

--- a/playwright/playwright.config.js
+++ b/playwright/playwright.config.js
@@ -8,6 +8,9 @@ const envUrls = {
   prod: process.env.PROD_URL,
 };
 
+// Store allure results inside this project regardless of cwd
+const resultsFolder = path.join(__dirname, 'allure-results');
+
 // The environment to run against is provided by the wrapper script `run-tests.js`
 // which sets `CURRENT_ENV`. For backwards compatibility we also read
 // `npm_config_env` when the script is invoked with `--env`.
@@ -20,7 +23,7 @@ module.exports = defineConfig({
   // <— run only one worker (i.e. serial execution)
   workers: 1,
   timeout: 2 * 60 * 1000,         // 2 minutes
-  reporter: [ ['list'], ['allure-playwright'] ],
+  reporter: [ ['list'], ['allure-playwright', { outputFolder: resultsFolder }] ],
   use: {
     headless: true,
     ignoreHTTPSErrors: true,


### PR DESCRIPTION
## Summary
- ensure Allure results path is always `playwright/allure-results`
- clarify README about fixed results location

## Testing
- `npm test staging`
- `npm run report:allure`


------
https://chatgpt.com/codex/tasks/task_e_68483fc3c4388327a6c11673086cc611