### PR TITLE
Attach screenshots on test failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,5 +90,6 @@ that data can be managed in a single location.
    npx allure open ./allure-report
    ```
 
-The report lists each test along with its pass/fail status, stack trace, and
-screenshot attachments captured by the hooks in `test-hooks.js`.
+The report lists each test along with its pass/fail status and stack trace.
+If a test fails, the hooks in `test-hooks.js` capture a screenshot which is
+attached to the report.

--- a/playwright/test-hooks.js
+++ b/playwright/test-hooks.js
@@ -4,16 +4,18 @@ const path = require('path');
 
 const test = base.test;
 
-// Capture a screenshot at the end of every test
-// and attach it to the test results.
+// Capture a screenshot if a test fails and attach it to the results.
 test.afterEach(async ({ page }, testInfo) => {
   if (!page) return;
-  const dir = path.join(__dirname, 'report', 'screenshots');
-  await fs.promises.mkdir(dir, { recursive: true });
-  const sanitized = testInfo.title.replace(/[^a-z0-9]+/gi, '_').toLowerCase();
-  const filePath = path.join(dir, `${sanitized}.png`);
-  await page.screenshot({ path: filePath, fullPage: true });
-  testInfo.attachments.push({ name: 'screenshot', path: filePath, contentType: 'image/png' });
+  // Only capture screenshots for failing tests so the report stays concise.
+  if (testInfo.status !== testInfo.expectedStatus) {
+    const dir = path.join(__dirname, 'report', 'screenshots');
+    await fs.promises.mkdir(dir, { recursive: true });
+    const sanitized = testInfo.title.replace(/[^a-z0-9]+/gi, '_').toLowerCase();
+    const filePath = path.join(dir, `${sanitized}.png`);
+    await page.screenshot({ path: filePath, fullPage: true });
+    testInfo.attachments.push({ name: 'screenshot', path: filePath, contentType: 'image/png' });
+  }
 });
 
 module.exports = { test, expect: base.expect };


### PR DESCRIPTION
## Summary
- capture screenshots only when a test fails
- document the failure screenshot capture in README

## Testing
- `npm test dev` *(fails: browser not installed / tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_684849d246f88327b397076653aa9d0b