### PR TITLE
Include environment info in Allure reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,5 @@ that data can be managed in a single location.
 The report lists each test along with its pass/fail status and stack trace.
 If a test fails, the hooks in `test-hooks.js` capture a screenshot which is
 attached to the report.
+The report also records the browser used and which deployment environment
+(`dev`, `staging`, or `prod`) was targeted during the run.

--- a/playwright/run-tests.js
+++ b/playwright/run-tests.js
@@ -1,12 +1,38 @@
 #!/usr/bin/env node
 const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 const args = process.argv.slice(2);
 const envName = args[0];
 if (!envName) {
   console.error('Usage: npm test <env> [playwright args]');
   process.exit(1);
 }
+
 process.env.CURRENT_ENV = envName;
+
+// Determine browser name from command line options. Default to chromium.
+let browser = 'chromium';
+for (const arg of args.slice(1)) {
+  if (arg.startsWith('--browser=')) {
+    browser = arg.split('=')[1];
+    break;
+  }
+  if (arg.startsWith('--project=')) {
+    browser = arg.split('=')[1];
+  }
+}
+
+// Write environment info for Allure report.
+try {
+  const resultsDir = path.join(__dirname, 'allure-results');
+  fs.mkdirSync(resultsDir, { recursive: true });
+  const envFile = path.join(resultsDir, 'environment.properties');
+  fs.writeFileSync(envFile, `Environment=${envName}\nBrowser=${browser}\n`);
+} catch (err) {
+  console.error('Failed to write environment properties', err);
+}
+
 const result = spawnSync('npx', ['playwright', 'test', ...args.slice(1)], {
   stdio: 'inherit',
   env: process.env,


### PR DESCRIPTION
## Summary
- show which environment is under test in README
- capture browser and environment info in `run-tests.js`

## Testing
- `npm test dev -- --list`

------
https://chatgpt.com/codex/tasks/task_e_68484e20eca483279bae74d9e65c387d