### PR TITLE
Add global setup for environment reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,8 @@ The report lists each test along with its pass/fail status and stack trace.
 If a test fails, the hooks in `test-hooks.js` capture a screenshot which is
 attached to the report.
 The report also records the browser used and which deployment environment
-(`dev`, `staging`, or `prod`) was targeted during the run.
+(`dev`, `staging`, or `prod`) was targeted during the run. This information is
+written automatically when the tests start in `global-setup.js`. As long as you
+launch the suite via `npm test <env>` (or set `CURRENT_ENV` when calling
+`npx playwright test`), the generated Allure report will include the environment
+and browser details.

--- a/playwright/global-setup.js
+++ b/playwright/global-setup.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+async function globalSetup(config) {
+  const envName = process.env.CURRENT_ENV || process.env.npm_config_env || 'staging';
+  const browser = config.projects?.[0]?.use?.browserName || 'chromium';
+  const resultsDir = path.join(__dirname, 'allure-results');
+  await fs.promises.mkdir(resultsDir, { recursive: true });
+  const envFile = path.join(resultsDir, 'environment.properties');
+  await fs.promises.writeFile(envFile, `Environment=${envName}\nBrowser=${browser}\n`);
+}
+
+module.exports = globalSetup;

--- a/playwright/playwright.config.js
+++ b/playwright/playwright.config.js
@@ -16,6 +16,7 @@ const baseURL = envUrls[currentEnv] || envUrls.staging;
 
 module.exports = defineConfig({
   testDir: './tests',
+  globalSetup: require.resolve('./global-setup'),
   retries: 0,
   // <— run only one worker (i.e. serial execution)
   workers: 1,


### PR DESCRIPTION
## Summary
- capture environment and browser info in `global-setup.js`
- configure Playwright to use the new setup
- clarify instructions on environment info in README

## Testing
- `npm test dev -- --max-failures=1`

------
https://chatgpt.com/codex/tasks/task_e_68485107c10483278ef8ed5fdd690529