### PR TITLE
Add company verification test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ venv/
 **/node_modules/
 playwright/test-results/
 playwright/report/
+playwright/allure-results/
+playwright/allure-report/

--- a/playwright/pages/company-verification-page.js
+++ b/playwright/pages/company-verification-page.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const { faker } = require('@faker-js/faker');
+
+class CompanyVerificationPage {
+  /**
+   * @param {import('@playwright/test').Page} page
+   */
+  constructor(page) {
+    this.page = page;
+  }
+
+  /** Navigate to the company verification page. */
+  async open() {
+    await this.page.getByRole('link', { name: /company verification/i }).click();
+  }
+
+  /** Fill the first step of company details and proceed. */
+  async fillCompanyDetails() {
+    await this.page.getByLabel(/company address/i).fill('123 Verification St');
+    await this.page.getByLabel(/city/i).fill('Nairobi');
+    await this.page.getByLabel(/country/i).selectOption('KE');
+    await this.page.getByRole('button', { name: /next/i }).click();
+  }
+
+  /** Fill usage information step and proceed. */
+  async fillUsageDetails() {
+    await this.page.getByLabel(/company size/i).selectOption('1-10');
+    await this.page.getByLabel(/expected transactions/i).fill('100');
+    await this.page.getByRole('button', { name: /next/i }).click();
+  }
+
+  /** Upload two verification documents and proceed. */
+  async uploadDocuments() {
+    const doc1 = path.join(__dirname, '../testdata/doc1.pdf');
+    const doc2 = path.join(__dirname, '../testdata/doc2.pdf');
+    const inputs = this.page.locator('input[type="file"]');
+    await inputs.nth(0).setInputFiles(doc1);
+    await inputs.nth(1).setInputFiles(doc2);
+    await this.page.getByRole('button', { name: /next/i }).click();
+  }
+
+  /** Complete all verification steps. */
+  async completeVerification() {
+    await this.open();
+    await this.fillCompanyDetails();
+    await this.fillUsageDetails();
+    await this.uploadDocuments();
+  }
+}
+
+module.exports = { CompanyVerificationPage };

--- a/playwright/testdata/doc1.pdf
+++ b/playwright/testdata/doc1.pdf
@@ -1,0 +1,1 @@
+dummy doc 1

--- a/playwright/testdata/doc2.pdf
+++ b/playwright/testdata/doc2.pdf
@@ -1,0 +1,1 @@
+dummy doc 2

--- a/playwright/tests/company-registration.spec.js
+++ b/playwright/tests/company-registration.spec.js
@@ -1,12 +1,34 @@
 const { test, expect } = require('../test-hooks');
 const { CompanyRegistrationPage } = require('../pages/company-registration-page');
+const { CompanyVerificationPage } = require('../pages/company-verification-page');
 
-// This test covers the full company sign-up process
+// Tests covering the company registration and verification flow.
 
-// Test: company registration flow using POM
+test.describe.serial('company onboarding', () => {
+  /** @type {import('@playwright/test').BrowserContext} */
+  let context;
+  /** @type {import('@playwright/test').Page} */
+  let page;
 
-test('create company account', async ({ page, context }) => {
-  const regPage = new CompanyRegistrationPage(page, context);
-  await regPage.registerCompany();
-  await expect(page.getByRole('link', { name: /dashboard/i })).toBeVisible();
+  test.beforeAll(async ({ browser }) => {
+    context = await browser.newContext();
+    page = await context.newPage();
+  });
+
+  test.afterAll(async () => {
+    await context.close();
+  });
+
+  // Test: company registration flow using POM
+  test('create company account', async () => {
+    const regPage = new CompanyRegistrationPage(page, context);
+    await regPage.registerCompany();
+    await expect(page.getByRole('link', { name: /dashboard/i })).toBeVisible();
+  });
+
+  // Continue the onboarding by completing company verification in the same browser session.
+  test('complete company verification', async () => {
+    const verifyPage = new CompanyVerificationPage(page);
+    await verifyPage.completeVerification();
+  });
 });


### PR DESCRIPTION
## Summary
- add CompanyVerificationPage for verifying company details
- extend registration spec with verification step
- add placeholder documents for upload
- ignore Allure output directories

## Testing
- `npm test staging -- --list`
- `npm test staging -- --grep "company onboarding" --timeout=10000` *(fails: browser not installed / OTP retrieval)*

------
https://chatgpt.com/codex/tasks/task_e_6848a713747c8327b69de3e7b2210f18