### PR TITLE
Configure CI to run Playwright tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,20 @@
+name: Playwright Tests
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: playwright
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npx playwright install chrome
+      - run: npm test staging --browser=chrome

--- a/README.md
+++ b/README.md
@@ -99,3 +99,7 @@ written automatically when the tests start in `global-setup.js`. As long as you
 launch the suite via `npm test <env>` (or set `CURRENT_ENV` when calling
 `npx playwright test`), the generated Allure report will include the environment
 and browser details.
+
+## Continuous Integration
+
+The Playwright test suite runs automatically on GitHub Actions after changes are merged into the `main` branch. The workflow file is located at `.github/workflows/playwright.yml` and executes the suite on a Windows runner using the Chrome browser.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run the Playwright suite on Windows using Chrome
- document the Windows CI configuration in the README

## Testing
- `node run-tests.js dev --browser=chromium` *(fails: missing OTP and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a0a80a2ec8327b0a9c0f68f529a68