### PR TITLE
Fix company verification address fields

### DIFF
--- a/playwright/pages/company-verification-page.js
+++ b/playwright/pages/company-verification-page.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { faker } = require('@faker-js/faker');
+const testData = require('../testdata');
 
 class CompanyVerificationPage {
   /**
@@ -16,9 +16,12 @@ class CompanyVerificationPage {
 
   /** Fill the first step of company details and proceed. */
   async fillCompanyDetails() {
-    await this.page.getByLabel(/company address/i).fill('123 Verification St');
-    await this.page.getByLabel(/city/i).fill('Nairobi');
-    await this.page.getByLabel(/country/i).selectOption('KE');
+    await this.page.locator('#addressLine1').fill(testData.company.addressLine1);
+    await this.page.locator('#addressLine2').fill(testData.company.addressLine2);
+    await this.page.locator('#city').fill(testData.company.city);
+    await this.page.locator('#postalCode').fill(testData.company.postalCode);
+    await this.page.locator('#companyPhone').fill(testData.company.phone);
+    await this.page.locator('#companyEmail').fill(testData.company.email);
     await this.page.getByRole('button', { name: /next/i }).click();
   }
 

--- a/playwright/testdata/index.js
+++ b/playwright/testdata/index.js
@@ -28,5 +28,11 @@ module.exports = {
   },
   company: {
     password: 'xpendless@A1',
+    addressLine1: '123 Verification St',
+    addressLine2: 'Suite 5',
+    city: 'Nairobi',
+    postalCode: '00100',
+    phone: '0712345678',
+    email: 'testcompany@yopmail.com',
   },
 };


### PR DESCRIPTION
## Summary
- use explicit field IDs for company verification address inputs
- add address fields to test data

## Testing
- `npm install`
- `npx playwright install --with-deps`
- `npm test dev` *(fails: login flow issues)*

------
https://chatgpt.com/codex/tasks/task_e_684a3383055c832787a72a7b5c4ca09f