### PR TITLE
Fix company verification step waits

### DIFF
--- a/playwright/pages/company-registration-page.js
+++ b/playwright/pages/company-registration-page.js
@@ -75,7 +75,7 @@ class CompanyRegistrationPage {
     await this.page.getByRole('button', { name: /register/i }).click();
 
     await this.page.getByRole('button', { name: /select plan|Get Subscription/i }).first().click();
-    await this.page.waitForTimeout(5000);
+    await this.page.waitForTimeout(10000);
 
     // Some flows allow skipping the subscription selection
     const skipButton = this.page.getByText(/^Skip$/i);

--- a/playwright/pages/company-verification-page.js
+++ b/playwright/pages/company-verification-page.js
@@ -23,9 +23,12 @@ class CompanyVerificationPage {
     await this.page.locator('#addressLine2').fill(testData.company.addressLine2);
     await this.page.locator('#city').fill(testData.company.city);
     await this.page.locator('#postalCode').fill(testData.company.postalCode);
+    await this.page.locator('#phoneNumber').waitFor();
     await this.page.locator('#phoneNumber').fill(testData.company.phone);
     await this.page.locator('#emailAddress').fill(testData.company.email);
-    await this.page.getByRole('button', { name: /next/i }).click();
+    const next = this.page.getByRole('button', { name: /next/i });
+    await next.waitFor();
+    await next.click();
   }
 
   /** Fill usage information step and proceed. */


### PR DESCRIPTION
## Summary
- extend delay after subscription selection
- fix failing verification step after postal code by waiting for phone number and Next button

## Testing
- `npm install`
- `npx playwright install`
- `CURRENT_ENV=staging npx playwright test` *(fails: could not fetch OTP from yopmail)*

------
https://chatgpt.com/codex/tasks/task_e_684a3b0c72108327995b5c6a19503a7b