### PR TITLE
Fix company phone and postal selectors

### DIFF
--- a/playwright/pages/company-verification-page.js
+++ b/playwright/pages/company-verification-page.js
@@ -23,10 +23,10 @@ class CompanyVerificationPage {
     await this.page.locator('#addressLine2').fill(testData.company.addressLine2);
     await this.page.locator('#city').fill(testData.company.city);
     await this.page.pause();
-    // await this.page.locator('#phoneNumber').waitFor();
-    await this.page.locator('#phoneNumber').fill(testData.company.phone);
+    // Use more specific locators as the page contains duplicate ids
+    await this.page.locator('input[name="companyPhone"]').fill(testData.company.phone);
     await this.page.locator('#emailAddress').fill(testData.company.email);
-    // await this.page.locator('#postalCode').fill(testData.company.postalCode);
+    await this.page.locator('input[name="postalCode"]').fill(testData.company.postalCode);
     // const next = this.page.getByRole('button', { name: /next/i });
     // await next.waitFor();
     // await next.click();


### PR DESCRIPTION
## Summary
- fix selectors for phone and postal code on the verification page

## Testing
- `CURRENT_ENV=staging npx playwright test tests/company-registration.spec.js` *(fails: locator.click: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_e_684a5b273650832780accd6bb6f1d95a