### PR TITLE
Add Allure report artifact

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,3 +18,10 @@ jobs:
       - run: npm ci
       - run: npx playwright install chrome
       - run: npm test staging --browser=chrome -- --reporter=line
+      - name: Generate Allure report
+        run: npm run report:allure
+      - name: Upload Allure report
+        uses: actions/upload-artifact@v4
+        with:
+          name: allure-report
+          path: playwright/allure-report

--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@ and browser details.
 
 ## Continuous Integration
 
-The Playwright test suite runs automatically on GitHub Actions after changes are merged into the `main` branch. The workflow file is located at `.github/workflows/playwright.yml` and executes the suite on a Windows runner using the Chrome browser.
+The Playwright test suite runs automatically on GitHub Actions after changes are merged into the `main` branch. The workflow file is located at `.github/workflows/playwright.yml` and executes the suite on a Windows runner using the Chrome browser. After each run, the job uploads the generated `allure-report` directory as a downloadable artifact so you can view the HTML results from the workflow page.


### PR DESCRIPTION
## Summary
- generate and publish Allure test report from CI
- document that the CI job uploads the report artifact
- update workflow to use actions/upload-artifact v4

## Testing
- `npm ci`
- `npx playwright install chrome`
- `npm test staging --browser=chrome -- --reporter=line` *(fails: browserType.launch: Executable doesn't exist)*
- `npm run report:allure`


------
https://chatgpt.com/codex/tasks/task_e_684a5bcdea9483279ac0ec1dd60f94e8