### PR TITLE
Use generated phone during company verification

### DIFF
--- a/playwright/pages/company-registration-page.js
+++ b/playwright/pages/company-registration-page.js
@@ -25,6 +25,7 @@ class CompanyRegistrationPage {
     const email = `${adminFirst.toLowerCase()}${faker.number.int({ min: 100, max: 999 })}@yopmail.com`;
     const companyName = `${adminFirst} Limited ${faker.number.int({ min: 100, max: 999 })}`;
     const mobile = `${Math.floor(100000000 + Math.random() * 900000000)}`;
+    this.mobile = mobile;
     const password = testData.company.password;
 
     // Begin registration on the landing page

--- a/playwright/pages/company-verification-page.js
+++ b/playwright/pages/company-verification-page.js
@@ -4,9 +4,11 @@ const testData = require('../testdata');
 class CompanyVerificationPage {
   /**
    * @param {import('@playwright/test').Page} page
+   * @param {string} [phone=testData.company.phone] - Phone number for verification
    */
-  constructor(page) {
+  constructor(page, phone = testData.company.phone) {
     this.page = page;
+    this.phone = phone;
   }
 
   /** Navigate to the company verification page. */
@@ -24,7 +26,7 @@ class CompanyVerificationPage {
     await this.page.locator('#city').fill(testData.company.city);
     
     // Use more specific locators as the page contains duplicate ids
-    await this.page.locator('input[name="companyPhone"]').fill(testData.company.phone);
+    await this.page.locator('input[name="companyPhone"]').fill(this.phone);
     await this.page.locator('#emailAddress').fill(testData.company.email);
     await this.page.locator('input[name="postalCode"]').fill(testData.company.postalCode);
     const next = this.page.getByRole('button', { name: /next/i });

--- a/playwright/tests/company-registration.spec.js
+++ b/playwright/tests/company-registration.spec.js
@@ -25,7 +25,7 @@ test.describe.serial('company onboarding', () => {
     await regPage.registerCompany();
     await expect(page.getByRole('link', { name: /dashboard/i })).toBeVisible();
 
-    const verifyPage = new CompanyVerificationPage(page);
+    const verifyPage = new CompanyVerificationPage(page, regPage.mobile);
     // debugger;
     await verifyPage.completeVerification();
   });


### PR DESCRIPTION
## Summary
- persist generated mobile number during registration
- allow company verification to accept a phone number
- pass generated phone from registration test into verification

## Testing
- `npm test staging` *(fails: unable to fetch OTP from yopmail)*

------
https://chatgpt.com/codex/tasks/task_e_68614cf6c9808327a2f1e1a5899415c1