### PR TITLE
Fix name generation and Next button

### DIFF
--- a/playwright/pages/company-registration-page.js
+++ b/playwright/pages/company-registration-page.js
@@ -20,8 +20,8 @@ class CompanyRegistrationPage {
    */
   async registerCompany() {
     // Generate basic details for the administrator and company
-    const adminFirst = faker.person.firstName();
-    const adminLast = faker.person.lastName();
+    const adminFirst = faker.person.firstName().replace(/[^a-zA-Z]/g, '');
+    const adminLast = faker.person.lastName().replace(/[^a-zA-Z]/g, '');
     const email = `${adminFirst.toLowerCase()}${faker.number.int({ min: 100, max: 999 })}@yopmail.com`;
     const companyName = `${adminFirst} Limited ${faker.number.int({ min: 100, max: 999 })}`;
     const mobile = `${Math.floor(100000000 + Math.random() * 900000000)}`;

--- a/playwright/pages/company-verification-page.js
+++ b/playwright/pages/company-verification-page.js
@@ -51,11 +51,9 @@ class CompanyVerificationPage {
     }
     // Some environments may render multiple "Next" buttons. Wait for the
     // visible, enabled one before clicking so that the flow reliably advances.
-    const nextButton = this.page.getByRole('button', { name: /next/i });
+    const nextButton = this.page.getByRole('button', { name: /^next$/i }).first();
     await nextButton.waitFor({ state: 'visible' });
-    // If the button is disabled until the dropdown selections are processed,
-    // wait for it to become enabled.
-    await this.page.waitForFunction(btn => !btn.disabled, nextButton);
+    await nextButton.waitFor({ state: 'enabled' });
     await nextButton.click();
   }
 


### PR DESCRIPTION
## Summary
- sanitize generated first and last names so they're alphabetic
- improve Next button locator in company verification flow

## Testing
- `npm test dev --silent` *(fails: no output due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68615e95e51883279e7e97e0eb5f34d0