### PR TITLE
Fix doc upload

### DIFF
--- a/playwright/pages/company-verification-page.js
+++ b/playwright/pages/company-verification-page.js
@@ -72,7 +72,8 @@ class CompanyVerificationPage {
     } else {
       // Fill two individual inputs sequentially.
       await inputs.nth(0).setInputFiles(doc1);
-      await this.page.waitForTimeout(1000);
+      // Wait for the second input to be ready before uploading
+      await inputs.nth(1).waitFor({ state: 'attached' });
       await inputs.nth(1).setInputFiles(doc2);
     }
 


### PR DESCRIPTION
## Summary
- wait for second file input before uploading in company verification page

## Testing
- `node run-tests.js dev tests/company-registration.spec.js` *(fails: browser dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865b2ebc99c83278420c3c9757c2f6e