### PR TITLE
Add Odoo staging navigation

### DIFF
--- a/playwright/pages/company-verification-page.js
+++ b/playwright/pages/company-verification-page.js
@@ -85,7 +85,6 @@ class CompanyVerificationPage {
     await this.open();
     await this.fillCompanyDetails();
     await this.fillUsageDetails();
-    await this.page.pause();
     await this.uploadDocuments();
   }
 }

--- a/playwright/pages/odoo-page.js
+++ b/playwright/pages/odoo-page.js
@@ -1,0 +1,23 @@
+const testData = require('../testdata');
+
+class OdooPage {
+  /**
+   * @param {import('@playwright/test').Page} page
+   */
+  constructor(page) {
+    this.page = page;
+  }
+
+  /** Navigate to the Odoo staging environment. */
+  async goto() {
+    await this.page.goto(testData.odoo.stagingUrl);
+  }
+
+  /** Open the KYB section and select My pipelines. */
+  async openKybMyPipelines() {
+    await this.page.getByRole('link', { name: /kyb/i }).click();
+    await this.page.getByRole('link', { name: /my pipelines/i }).click();
+  }
+}
+
+module.exports = { OdooPage };

--- a/playwright/testdata/index.js
+++ b/playwright/testdata/index.js
@@ -35,4 +35,7 @@ module.exports = {
     phone: '0712345678',
     email: 'testcompany@yopmail.com',
   },
+  odoo: {
+    stagingUrl: 'https://stg-odoo.xpendless.dev/odoo/action-483',
+  },
 };

--- a/playwright/tests/company-registration.spec.js
+++ b/playwright/tests/company-registration.spec.js
@@ -1,6 +1,7 @@
 const { test, expect } = require('../test-hooks');
 const { CompanyRegistrationPage } = require('../pages/company-registration-page');
 const { CompanyVerificationPage } = require('../pages/company-verification-page');
+const { OdooPage } = require('../pages/odoo-page');
 
 // Tests covering the company registration and verification flow.
 
@@ -28,5 +29,10 @@ test.describe.serial('company onboarding', () => {
     const verifyPage = new CompanyVerificationPage(page, regPage.mobile);
     // debugger;
     await verifyPage.completeVerification();
+
+    // After verification steps navigate to the Odoo staging environment
+    const odoo = new OdooPage(page);
+    await odoo.goto();
+    await odoo.openKybMyPipelines();
   });
 });


### PR DESCRIPTION
## Summary
- store Odoo staging URL in test data
- add helper page object for Odoo actions
- remove pause in verification flow
- after completing company verification, open Odoo and navigate to `KYB > My pipelines`

## Testing
- `npm install`
- `npx playwright install`
- `npm test staging` *(fails: could not complete due to missing dependencies and network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6865bcf56418832790f6d92516706741