### PR TITLE
Implement Odoo login step

### DIFF
--- a/playwright/pages/odoo-page.js
+++ b/playwright/pages/odoo-page.js
@@ -8,6 +8,17 @@ class OdooPage {
     this.page = page;
   }
 
+  /**
+   * Log into the Odoo instance using provided credentials.
+   * @param {string} [username=testData.odoo.username] - Odoo account email.
+   * @param {string} [password=testData.odoo.password] - Odoo account password.
+   */
+  async login(username = testData.odoo.username, password = testData.odoo.password) {
+    await this.page.getByLabel(/email/i).fill(username);
+    await this.page.getByLabel(/password/i).fill(password);
+    await this.page.getByRole('button', { name: /log in/i }).click();
+  }
+
   /** Navigate to the Odoo staging environment. */
   async goto() {
     await this.page.goto(testData.odoo.stagingUrl);

--- a/playwright/testdata/index.js
+++ b/playwright/testdata/index.js
@@ -37,5 +37,7 @@ module.exports = {
   },
   odoo: {
     stagingUrl: 'https://stg-odoo.xpendless.dev/odoo/action-483',
+    username: 'info@xpendless.com',
+    password: 'abc123',
   },
 };

--- a/playwright/tests/company-registration.spec.js
+++ b/playwright/tests/company-registration.spec.js
@@ -33,6 +33,7 @@ test.describe.serial('company onboarding', () => {
     // After verification steps navigate to the Odoo staging environment
     const odoo = new OdooPage(page);
     await odoo.goto();
+    await odoo.login();
     await odoo.openKybMyPipelines();
   });
 });


### PR DESCRIPTION
## Summary
- add Odoo credentials to shared test data
- implement login method in OdooPage
- login on Odoo after navigation during company onboarding test

## Testing
- `npm install`
- `npx playwright install`
- `npm test staging -- --max-failures=1` *(fails: Test timeout of 30000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_6865c3557bdc83278bcffa86401ff269