### PR TITLE
Fix navigation after logging into Odoo

### DIFF
--- a/playwright/pages/odoo-page.js
+++ b/playwright/pages/odoo-page.js
@@ -16,7 +16,10 @@ class OdooPage {
   async login(username = testData.odoo.username, password = testData.odoo.password) {
     await this.page.getByLabel(/email/i).fill(username);
     await this.page.getByLabel(/password/i).fill(password);
-    await this.page.getByRole('button', { name: /log in/i }).click();
+    await Promise.all([
+      this.page.waitForNavigation({ waitUntil: 'networkidle' }),
+      this.page.getByRole('button', { name: /log in/i }).click(),
+    ]);
   }
 
   /** Navigate to the Odoo staging environment. */
@@ -26,8 +29,13 @@ class OdooPage {
 
   /** Open the KYB section and select My pipelines. */
   async openKybMyPipelines() {
-    await this.page.getByRole('link', { name: /kyb/i }).click();
-    await this.page.getByRole('link', { name: /my pipelines/i }).click();
+    const kybLink = this.page.getByRole('link', { name: /kyb/i });
+    await kybLink.waitFor();
+    await kybLink.click();
+
+    const pipelineLink = this.page.getByRole('link', { name: /my pipelines/i });
+    await pipelineLink.waitFor();
+    await pipelineLink.click();
   }
 }
 


### PR DESCRIPTION
## Summary
- wait for navigation after clicking the Odoo login button
- ensure KYB menu items appear before interaction

## Testing
- `npm test staging` *(fails: missing host dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865c5c9ebec832780a6a07fad353d3e