### PR TITLE
Add company verification step

### DIFF
--- a/playwright/pages/company-registration-page.js
+++ b/playwright/pages/company-registration-page.js
@@ -25,7 +25,11 @@ class CompanyRegistrationPage {
     const email = `${adminFirst.toLowerCase()}${faker.number.int({ min: 100, max: 999 })}@yopmail.com`;
     const companyName = `${adminFirst} Limited ${faker.number.int({ min: 100, max: 999 })}`;
     const mobile = `${Math.floor(100000000 + Math.random() * 900000000)}`;
+
+    // expose generated values for later verification steps
     this.mobile = mobile;
+    this.companyName = companyName;
+    this.email = email;
     const password = testData.company.password;
 
     // Begin registration on the landing page
@@ -73,6 +77,9 @@ class CompanyRegistrationPage {
     await this.page.getByLabel(/company name/i).fill(companyName);
     const regNo = `${Math.floor(10000000 + Math.random() * 90000000)}`;
     await this.page.getByLabel(/registration number/i).fill(regNo);
+
+    // store for later verification in Odoo
+    this.registrationNumber = regNo;
     await this.page.getByRole('button', { name: /register/i }).click();
 
     await this.page.getByRole('button', { name: /select plan|Get Subscription/i }).first().click();

--- a/playwright/pages/odoo-page.js
+++ b/playwright/pages/odoo-page.js
@@ -1,3 +1,4 @@
+const { expect } = require('@playwright/test');
 const testData = require('../testdata');
 
 class OdooPage {
@@ -58,6 +59,25 @@ class OdooPage {
     const firstRow = this.page.locator('tbody tr').first();
     await firstRow.waitFor();
     await firstRow.click();
+  }
+
+  /**
+   * Verify that the opened company details match expected values.
+   * @param {{name?: string, registration?: string, phone?: string, email?: string}} expected
+   */
+  async verifyCompanyDetails(expected) {
+    if (expected.name) {
+      await expect(this.page.getByText(expected.name, { exact: false })).toBeVisible();
+    }
+    if (expected.registration) {
+      await expect(this.page.getByText(expected.registration, { exact: false })).toBeVisible();
+    }
+    if (expected.phone) {
+      await expect(this.page.getByText(expected.phone, { exact: false })).toBeVisible();
+    }
+    if (expected.email) {
+      await expect(this.page.getByText(expected.email, { exact: false })).toBeVisible();
+    }
   }
 }
 

--- a/playwright/tests/company-registration.spec.js
+++ b/playwright/tests/company-registration.spec.js
@@ -36,5 +36,11 @@ test.describe.serial('company onboarding', () => {
     await odoo.login();
     await odoo.openKybMyPipelines();
     await odoo.openFirstCompany();
+    await odoo.verifyCompanyDetails({
+      name: regPage.companyName,
+      registration: regPage.registrationNumber,
+      phone: regPage.mobile,
+      email: regPage.email,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- store generated company details in the registration page object
- add a helper on the Odoo page to confirm company details
- verify company info in `company-registration` test

## Testing
- `npm install`
- `npx playwright install`
- `npm test staging` *(fails: unable to complete playwright tests)*

------
https://chatgpt.com/codex/tasks/task_e_686da5d5ac908327a67c8091ccf1c2c1