### PR TITLE
Fix company name verification

### DIFF
--- a/playwright/pages/odoo-page.js
+++ b/playwright/pages/odoo-page.js
@@ -67,7 +67,8 @@ class OdooPage {
    */
   async verifyCompanyDetails(expected) {
     if (expected.name) {
-      await expect(this.page.getByText(expected.name, { exact: false })).toBeVisible();
+      const nameInput = this.page.locator('#name_0');
+      await expect(nameInput).toHaveValue(expected.name);
     }
     if (expected.registration) {
       await expect(this.page.getByText(expected.registration, { exact: false })).toBeVisible();


### PR DESCRIPTION
## Summary
- verify company name using the input with id `name_0`

## Testing
- `npm test staging` *(fails: login/OTP related errors)*

------
https://chatgpt.com/codex/tasks/task_e_686daa8b4ffc8327b05ff3c53ac385d0