### PR TITLE
Add console logs for Odoo verification

### DIFF
--- a/playwright/pages/odoo-page.js
+++ b/playwright/pages/odoo-page.js
@@ -63,24 +63,38 @@ class OdooPage {
 
   /**
    * Verify that the opened company details match expected values.
-   * @param {{name?: string, registration?: string, phone?: string, email?: string}} expected
+   * @param {{name?: string, registration?: string, phone?: string, email?: string, address?: string}} expected
    */
   async verifyCompanyDetails(expected) {
     if (expected.name) {
       const nameInput = this.page.locator('#name_0');
+      const value = await nameInput.inputValue();
+      console.log('Name:', value);
       await expect(nameInput).toHaveValue(expected.name);
     }
     if (expected.registration) {
-      const regInput = this.page.getByLabel(/registration number/i);
+      const regInput = this.page.getByRole('textbox', { name: 'Reg. No.' });
+      const value = await regInput.inputValue();
+      console.log('Reg. No.:', value);
       await expect(regInput).toHaveValue(expected.registration);
     }
     if (expected.phone) {
-      const phoneInput = this.page.getByLabel(/phone/i);
+      const phoneInput = this.page.locator('#phone_2');
+      const value = await phoneInput.inputValue();
+      console.log('Phone:', value);
       await expect(phoneInput).toHaveValue(expected.phone);
     }
     if (expected.email) {
-      const emailInput = this.page.getByLabel(/email/i);
+      const emailInput = this.page.locator('#email_from_2');
+      const value = await emailInput.inputValue();
+      console.log('Email:', value);
       await expect(emailInput).toHaveValue(expected.email);
+    }
+    if (expected.address) {
+      const addressInput = this.page.getByRole('textbox', { name: 'Street...' });
+      const value = await addressInput.inputValue();
+      console.log('Address:', value);
+      await expect(addressInput).toHaveValue(expected.address);
     }
   }
 }

--- a/playwright/tests/company-registration.spec.js
+++ b/playwright/tests/company-registration.spec.js
@@ -2,6 +2,7 @@ const { test, expect } = require('../test-hooks');
 const { CompanyRegistrationPage } = require('../pages/company-registration-page');
 const { CompanyVerificationPage } = require('../pages/company-verification-page');
 const { OdooPage } = require('../pages/odoo-page');
+const testData = require('../testdata');
 
 // Tests covering the company registration and verification flow.
 
@@ -41,6 +42,7 @@ test.describe.serial('company onboarding', () => {
       registration: regPage.registrationNumber,
       phone: regPage.mobile,
       email: regPage.email,
+      address: testData.company.addressLine1,
     });
   });
 });


### PR DESCRIPTION
## Summary
- log Odoo field values to console during verification
- use specific locators for Reg. No., phone, email and address fields
- check address in company registration test

## Testing
- `npm test staging -- --list`
- `npm test staging -- --max-failures 1` *(fails: Cannot read properties of undefined (reading 'close'))*

------
https://chatgpt.com/codex/tasks/task_e_686efc2385808327a5c471034ed43b55