### PR TITLE
Add accept & verify step to company registration

### DIFF
--- a/playwright/pages/odoo-page.js
+++ b/playwright/pages/odoo-page.js
@@ -98,6 +98,34 @@ class OdooPage {
       await expect(addressInput).toHaveValue(expected.address);
     }
   }
+
+  /**
+   * Accept the company and then verify it within Odoo.
+   * Assumes the company details page is already open.
+   */
+  async acceptAndVerifyCompany() {
+    const acceptButton = this.page.getByRole('button', { name: /accept/i });
+    await acceptButton.waitFor();
+    await acceptButton.click();
+
+    const okButton = this.page.getByRole('button', { name: /^ok$/i });
+    await okButton.waitFor();
+    await okButton.click();
+
+    // Wait for the confirmation dialog to disappear
+    await this.page.waitForTimeout(3000);
+
+    // After accepting, a Verify button appears in the same spot
+    const verifyButton = this.page.getByRole('button', { name: /verify/i });
+    await verifyButton.waitFor();
+    await verifyButton.click();
+
+    await okButton.waitFor();
+    await okButton.click();
+
+    // Allow backend processing a little time before continuing
+    await this.page.waitForTimeout(5000);
+  }
 }
 
 module.exports = { OdooPage };

--- a/playwright/tests/company-registration.spec.js
+++ b/playwright/tests/company-registration.spec.js
@@ -46,5 +46,7 @@ test.describe.serial('company onboarding', () => {
       email: testData.company.email,
       address: testData.company.addressLine1,
     });
+
+    await odoo.acceptAndVerifyCompany();
   });
 });


### PR DESCRIPTION
## Summary
- update Odoo page object with new `acceptAndVerifyCompany` helper
- call the helper from the registration spec

## Testing
- `npm test dev -- --list`

------
https://chatgpt.com/codex/tasks/task_e_68819a2ca56883279b3c733319624311