### PR TITLE
Update staging URL and login creds

### DIFF
--- a/playwright/.env
+++ b/playwright/.env
@@ -1,3 +1,3 @@
-STAGING_URL=https://xpendless-frontend-staging-d6pkpujjuq-ww.a.run.app
+STAGING_URL=https://xpendless-frontend-staging-662524170977.me-central1.run.app
 DEV_URL=https://xpendless-frontend-dev-385254729743.me-central1.run.app
 PROD_URL=https://app.xpendless.dev

--- a/playwright/tests/login.spec.js
+++ b/playwright/tests/login.spec.js
@@ -5,14 +5,14 @@ const testData = require('../testdata');
 // Verify that a user can log into the application
 test('login with OTP', async ({ page, context }) => {
   const loginPage = new LoginPage(page, context);
-  await loginPage.login(testData.credentials.email, testData.credentials.password);
+  await loginPage.login(testData.company.email, testData.company.password);
   await expect(page.getByRole('link', { name: /dashboard/i })).toBeVisible();
 });
 
 // Ensure that the logout functionality works
 test('logout via icon', async ({ page, context }) => {
   const loginPage = new LoginPage(page, context);
-  await loginPage.login(testData.credentials.email, testData.credentials.password);
+  await loginPage.login(testData.company.email, testData.company.password);
   await loginPage.logout();
   await expect(page.getByLabel('Email address')).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- update STAGING_URL in `.env`
- use company credentials for login tests

## Testing
- `npm test staging` *(fails: browserType.launch missing dependencies, 3 failed, 1 interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688b49e226dc832781f70bd840e0c6e5