### PR TITLE
Update credentials across tests

### DIFF
--- a/playwright/pages/login-page.js
+++ b/playwright/pages/login-page.js
@@ -12,6 +12,8 @@ class LoginPage {
   constructor(page, context) {
     this.page = page;
     this.context = context;
+    /** @type {string|undefined} */
+    this.email = undefined;
   }
 
   /**
@@ -68,6 +70,7 @@ class LoginPage {
     logger.log('Submit OTP and login');
     await this.page.getByRole('button', { name: 'Login' }).click();
     await this.page.getByRole('link', { name: /dashboard/i }).waitFor();
+    this.email = email;
   }
 
   /**
@@ -77,7 +80,8 @@ class LoginPage {
   async logout() {
     const logoutLink = this.page.getByRole('link', { name: /logout/i });
     if (!(await logoutLink.isVisible())) {
-      const userMenu = this.page.getByText(/ryan_adams1/i);
+      const username = this.email ? this.email.split('@')[0].toLowerCase() : '';
+      const userMenu = this.page.getByText(new RegExp(username, 'i'));
       if (await userMenu.isVisible()) {
         logger.log('Open user menu');
         await userMenu.click();

--- a/playwright/testdata/index.js
+++ b/playwright/testdata/index.js
@@ -3,6 +3,15 @@ module.exports = {
     email: 'Ryan_Adams1@yopmail.com',
     password: 'Xpendless@A1',
   },
+  /**
+   * Update the credentials used by tests at runtime.
+   * @param {string} email - The email address to use for subsequent logins.
+   * @param {string} [password] - Optional password, defaults to existing one.
+   */
+  updateCredentials(email, password) {
+    if (email) this.credentials.email = email;
+    if (password) this.credentials.password = password;
+  },
   otp: {
     mobile: '123456',
   },

--- a/playwright/tests/company-registration.spec.js
+++ b/playwright/tests/company-registration.spec.js
@@ -31,6 +31,9 @@ test.describe.serial('company onboarding', () => {
     // debugger;
     await verifyPage.completeVerification();
 
+    // Use the newly created admin account for subsequent tests
+    testData.updateCredentials(regPage.email, testData.company.password);
+
     // After verification steps navigate to the Odoo staging environment
     const odoo = new OdooPage(page);
     await odoo.goto();

--- a/playwright/tests/login.spec.js
+++ b/playwright/tests/login.spec.js
@@ -5,14 +5,14 @@ const testData = require('../testdata');
 // Verify that a user can log into the application
 test('login with OTP', async ({ page, context }) => {
   const loginPage = new LoginPage(page, context);
-  await loginPage.login(testData.company.email, testData.company.password);
+  await loginPage.login(testData.credentials.email, testData.credentials.password);
   await expect(page.getByRole('link', { name: /dashboard/i })).toBeVisible();
 });
 
 // Ensure that the logout functionality works
 test('logout via icon', async ({ page, context }) => {
   const loginPage = new LoginPage(page, context);
-  await loginPage.login(testData.company.email, testData.company.password);
+  await loginPage.login(testData.credentials.email, testData.credentials.password);
   await loginPage.logout();
   await expect(page.getByLabel('Email address')).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- allow test credentials to be updated dynamically
- set credentials from registration test after company creation
- use dynamic credentials in login tests
- update logout to derive user menu text from email

## Testing
- `npm test dev -- --max-failures=1` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_688b516a20148327bcaad869d34f66cd