### PR TITLE
Use dynamic credentials across tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ playwright/report/
 playwright/allure-results/
 playwright/allure-report/
 playwright/logs/
+playwright/testdata/credentials.json

--- a/playwright/global-setup.js
+++ b/playwright/global-setup.js
@@ -8,6 +8,14 @@ async function globalSetup(config) {
   await fs.promises.mkdir(resultsDir, { recursive: true });
   const envFile = path.join(resultsDir, 'environment.properties');
   await fs.promises.writeFile(envFile, `Environment=${envName}\nBrowser=${browser}\n`);
+
+  // Remove any stored credentials so tests start fresh
+  const credFile = path.join(__dirname, 'testdata', 'credentials.json');
+  try {
+    await fs.promises.unlink(credFile);
+  } catch {
+    // ignore if file does not exist
+  }
 }
 
 module.exports = globalSetup;

--- a/playwright/testdata/index.js
+++ b/playwright/testdata/index.js
@@ -1,7 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+const credPath = path.join(__dirname, 'credentials.json');
+let storedCreds = {};
+try {
+  storedCreds = JSON.parse(fs.readFileSync(credPath, 'utf8'));
+} catch {
+  // file does not exist or is invalid, fall back to defaults
+}
+
 module.exports = {
   credentials: {
-    email: 'Ryan_Adams1@yopmail.com',
-    password: 'Xpendless@A1',
+    email: storedCreds.email || 'Ryan_Adams1@yopmail.com',
+    password: storedCreds.password || 'Xpendless@A1',
   },
   /**
    * Update the credentials used by tests at runtime.
@@ -11,6 +22,11 @@ module.exports = {
   updateCredentials(email, password) {
     if (email) this.credentials.email = email;
     if (password) this.credentials.password = password;
+    try {
+      fs.writeFileSync(credPath, JSON.stringify(this.credentials));
+    } catch {
+      // ignore file write errors
+    }
   },
   otp: {
     mobile: '123456',


### PR DESCRIPTION
## Summary
- persist credentials to a file so other tests can use the random email
- clear the credentials file before running tests
- ignore the credentials file in git

## Testing
- `node run-tests.js staging --list`
- `node run-tests.js staging tests/login.spec.js --grep "login with OTP"` *(fails: Please enter OTP)*

------
https://chatgpt.com/codex/tasks/task_e_688b5620863883278ff657a2f90a7476