### PR TITLE
fix: update usage details selectors

### DIFF
--- a/playwright/pages/company-verification-page.js
+++ b/playwright/pages/company-verification-page.js
@@ -45,22 +45,52 @@ class CompanyVerificationPage {
 
   /** Fill usage information step and proceed. */
   async fillUsageDetails() {
-    // The usage page contains three drop downs. Select a random option from
-    // each to avoid assumptions about the available values.
-    const dropdowns = this.page.locator('form select');
-    const count = await dropdowns.count();
-    for (let i = 0; i < Math.min(count, 3); i++) {
-      const select = dropdowns.nth(i);
-      await select.waitFor();
-      const options = await select.locator('option').all();
-      if (options.length === 0) continue;
-      const choice = options[Math.floor(Math.random() * options.length)];
-      const value = await choice.getAttribute('value');
-      await select.selectOption(value ?? { index: 0 });
-    };
-    // Some environments may render multiple "Next" buttons. Wait for the
-    // visible, enabled one before clicking so that the flow reliably advances.
-    const nextButton = this.page.locator('#usage_next');
+    // The component previously used simple <select> elements. Some
+    // environments have moved to tab-style selectors. Try the legacy
+    // dropdowns first and fall back to clicking tabs if no selects exist.
+
+    const dropdowns = this.page.locator('select');
+    const dropdownCount = await dropdowns.count();
+
+    if (dropdownCount > 0) {
+      for (let i = 0; i < dropdownCount; i++) {
+        const select = dropdowns.nth(i);
+        await select.waitFor();
+        // Prefer the first non-empty option so the selection is meaningful
+        const value = await select.evaluate((el) => {
+          const option = Array.from(el.options).find(
+            (o) => !o.disabled && o.value && o.value.trim() !== ''
+          );
+          return option ? option.value : null;
+        });
+        if (value) {
+          await select.selectOption(value);
+        } else {
+          // Fallback to the second option if available, otherwise the first
+          const optionCount = await select.locator('option').count();
+          const index = optionCount > 1 ? 1 : 0;
+          await select.selectOption({ index });
+        }
+      }
+    } else {
+      // New interface renders options as tabs. For each tablist, pick the
+      // first available tab. This keeps the test resilient to future
+      // additions without relying on specific text.
+      const tablists = this.page.locator('[role="tablist"]');
+      const listCount = await tablists.count();
+      for (let i = 0; i < listCount; i++) {
+        const tabs = tablists.nth(i).locator('[role="tab"]');
+        if (await tabs.count() === 0) continue;
+        await tabs.nth(0).click();
+      }
+    }
+
+    // The "Next" button id changed during redesign. Attempt the previous id
+    // and fall back to a generic role-based locator.
+    let nextButton = this.page.locator('#usage_next');
+    if (await nextButton.count() === 0) {
+      nextButton = this.page.getByRole('button', { name: /next/i }).last();
+    }
     logger.log('Click next on usage details');
     await nextButton.click();
   }


### PR DESCRIPTION
## Summary
- broaden usage details dropdown selector and prefer first non-empty choice
- retain tab-based fallback for new interfaces

## Testing
- `npm test dev tests/company-registration.spec.js -- --project=chromium` *(fails: TypeError: Cannot read properties of undefined (reading 'close'))*
- `npx playwright install --with-deps` *(partial install; large dependency set prevented completion)*

------
https://chatgpt.com/codex/tasks/task_e_688f209835088327b93c7b47f2f8588d