### PR TITLE
Select random options from usage dropdowns

### DIFF
--- a/playwright/pages/company-verification-page.js
+++ b/playwright/pages/company-verification-page.js
@@ -80,9 +80,12 @@ class CompanyVerificationPage {
     for (const dropdown of usageDropdowns) {
       await dropdown.click();
 
-      // Retrieve all options from the currently opened listbox and choose one
-      // at random. The dropdown closes automatically after selection.
-      const options = this.page.locator('[role="listbox"] [role="option"]');
+      // Retrieve options from the listbox that opened for this dropdown and
+      // choose one at random. The dropdown closes automatically after
+      // selection.
+      const listbox = this.page.locator('[role="listbox"]').last();
+      await listbox.waitFor();
+      const options = listbox.locator('[role="option"]');
       const count = await options.count();
       if (count === 0) {
         continue;


### PR DESCRIPTION
## Summary
- ensure usage dropdowns choose a random option by waiting for the associated listbox

## Testing
- `npm test dev -- --list`


------
https://chatgpt.com/codex/tasks/task_e_688f34a719208327848c5dd9e790f991