### PR TITLE
Ensure waits in company verification and Odoo login

### DIFF
--- a/playwright/pages/company-verification-page.js
+++ b/playwright/pages/company-verification-page.js
@@ -158,8 +158,9 @@ class CompanyVerificationPage {
     await this.open();
     await this.fillCompanyDetails();
     await this.fillUsageDetails();
-    logger.log('Pausing before document upload');
-    await this.page.pause();
+    // Ensure the usage details form is fully submitted before proceeding
+    logger.log('Wait for form submission before document upload');
+    await this.page.waitForTimeout(3000);
     await this.uploadDocuments();
   }
 }

--- a/playwright/pages/odoo-page.js
+++ b/playwright/pages/odoo-page.js
@@ -30,6 +30,8 @@ class OdooPage {
   /** Navigate to the Odoo staging environment. */
   async goto() {
     await this.page.goto(testData.odoo.stagingUrl);
+    // Wait for the page to fully load before attempting to log in
+    await this.page.waitForLoadState('domcontentloaded');
     // Wait for the login fields to appear as the page can take a moment to load
     await this.page.getByLabel(/email/i).waitFor();
     await this.page.getByLabel(/password/i).waitFor();


### PR DESCRIPTION
## Summary
- wait after usage details before uploading documents in company verification
- wait for Odoo page to load before attempting login

## Testing
- `npm test dev -- tests/login.spec.js -g "login with OTP"` *(fails: Test timeout of 30000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_689298db50148327b1d58c7810ac958a