### PR TITLE
Improve Odoo page loading and dropdown handling

### DIFF
--- a/playwright/pages/company-verification-page.js
+++ b/playwright/pages/company-verification-page.js
@@ -76,11 +76,9 @@ class CompanyVerificationPage {
       let options;
       if (listboxId) {
         const listbox = this.page.locator(`#${listboxId}`);
-        await listbox.waitFor();
         options = listbox.locator('[role="option"]');
       } else {
         const listbox = this.page.locator('[role="listbox"]').last();
-        await listbox.waitFor();
         options = listbox.locator('[role="option"]');
       }
 

--- a/playwright/pages/odoo-page.js
+++ b/playwright/pages/odoo-page.js
@@ -31,7 +31,7 @@ class OdooPage {
   async goto() {
     await this.page.goto(testData.odoo.stagingUrl);
     // Wait for the page to fully load before attempting to log in
-    await this.page.waitForLoadState('domcontentloaded');
+    await this.page.waitForLoadState('networkidle');
     // Wait for the login fields to appear as the page can take a moment to load
     await this.page.getByLabel(/email/i).waitFor();
     await this.page.getByLabel(/password/i).waitFor();


### PR DESCRIPTION
## Summary
- remove unnecessary `waitFor` on listboxes to speed dropdown resolution
- wait for full network idle when navigating to Odoo before login

## Testing
- `npm test test` *(fails: ReferenceError: page1 is not defined; 2 failed, 1 interrupted, 21 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_68929c9e7b348327bef122e9cbc5d5a8