### PR TITLE
Wait for uploads and Odoo page readiness

### DIFF
--- a/playwright/pages/company-verification-page.js
+++ b/playwright/pages/company-verification-page.js
@@ -147,8 +147,10 @@ class CompanyVerificationPage {
       // await inputs.nth(1).waitFor({ state: 'attached' });
       // await inputs.nth(1).setInputFiles(doc2);
     }
-
-    // await this.page.getByRole('button', { name: /next/i }).click();
+    // Allow some time for the documents to finish uploading before continuing
+    await this.page.waitForTimeout(3000);
+    logger.log('Click next after document upload');
+    await this.page.getByRole('button', { name: /next/i }).click();
   }
 
   /** Complete all verification steps. */

--- a/playwright/pages/odoo-page.js
+++ b/playwright/pages/odoo-page.js
@@ -19,22 +19,21 @@ class OdooPage {
     const passwordField = this.page.getByLabel(/password/i);
     await emailField.fill(username);
     await passwordField.fill(password);
-    await Promise.all([
-      // this.page.waitForNavigation({ waitUntil: 'networkidle' }),
-      this.page.getByRole('button', { name: /log in/i }).click(),
-    ]);
-    // Ensure the dashboard is fully loaded before continuing
+    // Submit the form and wait for the dashboard to load
+    await this.page.getByRole('button', { name: /log in/i }).click();
+    await this.page.waitForLoadState('networkidle');
+    // Ensure the dashboard is fully ready before interacting
     await this.page.getByRole('button', { name: 'KYB' }).waitFor();
   }
 
   /** Navigate to the Odoo staging environment. */
   async goto() {
-    await this.page.goto(testData.odoo.stagingUrl);
-    // Wait for the page to fully load before attempting to log in
+    await this.page.goto(testData.odoo.stagingUrl, { waitUntil: 'domcontentloaded' });
+    // Ensure all network activity has settled and the login form is visible
     await this.page.waitForLoadState('networkidle');
-    // Wait for the login fields to appear as the page can take a moment to load
     await this.page.getByLabel(/email/i).waitFor();
     await this.page.getByLabel(/password/i).waitFor();
+    await this.page.getByRole('button', { name: /log in/i }).waitFor();
   }
 
   /**


### PR DESCRIPTION
## Summary
- wait for document uploads to settle before proceeding in company verification
- ensure Odoo login page is ready before input and wait for dashboard after login

## Testing
- `npm test staging -- --max-failures=1` *(fails: TypeError: Cannot read properties of undefined (reading 'close'))*

------
https://chatgpt.com/codex/tasks/task_e_6892a130a3908327a7cf3daa0d54a372