### PR TITLE
Select Enterprise plan in company registration

### DIFF
--- a/playwright/pages/company-registration-page.js
+++ b/playwright/pages/company-registration-page.js
@@ -103,17 +103,17 @@ class CompanyRegistrationPage {
     logger.log('Click register company');
     await this.page.getByRole('button', { name: /register/i }).click();
 
-    logger.log('Select subscription plan');
-    await this.page.getByRole('button', { name: /select plan|Get Subscription/i }).first().click();
+    logger.log('Select Enterprise subscription plan');
+    await this.page.locator('#subscription_3').click();
     // await this.page.waitForTimeout(10000);
 
-    // Some flows allow skipping the subscription selection
+    // Some flows allow skipping the subscription payment
     const skipButton = this.page.getByText(/^Skip$/i);
     await skipButton.waitFor({ state: 'visible', timeout: 15000 });
     // if (await skipButton.isVisible()) {
     //   await skipButton.click();
     // }
-    logger.log('Skip subscription selection');
+    logger.log('Skip subscription payment');
     await skipButton.click();
 
     await this.page.getByRole('link', { name: /dashboard/i }).waitFor();


### PR DESCRIPTION
## Summary
- choose the Enterprise subscription during company registration using its dedicated button id
- rename log messages to reflect skipping payment

## Testing
- `npx playwright install --with-deps chromium`
- `npm test dev -- --project=chromium tests/company-registration.spec.js` *(fails: expected company name mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6893d76257cc8327a244089de1220c6d