### PR TITLE
Use single log file per test run

### DIFF
--- a/playwright/logger.js
+++ b/playwright/logger.js
@@ -1,14 +1,21 @@
 const fs = require('fs');
 const path = require('path');
 
-let stream = null;
+// Create a single log file for the entire test run. The timestamp is
+// generated once when this module is first required and reused for all
+// subsequent calls so that every test writes into the same file.
+const logsDir = path.join(__dirname, 'logs');
+fs.mkdirSync(logsDir, { recursive: true });
+const runTimestamp = new Date().toISOString().replace(/[:.]/g, '-');
+const filePath = path.join(logsDir, `${runTimestamp}.log`);
+let stream = fs.createWriteStream(filePath, { flags: 'a' });
 
 function start(testTitle) {
-  const logsDir = path.join(__dirname, 'logs');
-  fs.mkdirSync(logsDir, { recursive: true });
-  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const filePath = path.join(logsDir, `${timestamp}.log`);
-  stream = fs.createWriteStream(filePath, { flags: 'a' });
+  if (!stream) {
+    // In case the stream was manually closed, recreate it using the same
+    // run timestamp so all logs for this execution stay in one file.
+    stream = fs.createWriteStream(filePath, { flags: 'a' });
+  }
   stream.write(`${new Date().toISOString()} - Test: ${testTitle}\n`);
 }
 
@@ -19,10 +26,16 @@ function log(message) {
 }
 
 function end() {
+  // Do not close the stream after each test; keep it open for the entire
+  // run so that subsequent tests append to the same file. The stream will
+  // be closed on process exit.
+}
+
+process.on('exit', () => {
   if (stream) {
     stream.end();
     stream = null;
   }
-}
+});
 
 module.exports = { start, log, end };


### PR DESCRIPTION
## Summary
- create a single log file for an entire test execution
- prevent closing the log between tests and close on process exit

## Testing
- `npm test dev -- tests/demo.spec.js --project=chromium` *(fails: test interrupted while navigating)*

------
https://chatgpt.com/codex/tasks/task_e_6893df4d746883278bc7019df6c73622