### PR TITLE
feat: add department creation test

### DIFF
--- a/playwright/pages/teams-page.js
+++ b/playwright/pages/teams-page.js
@@ -1,0 +1,32 @@
+const logger = require('../logger');
+
+/**
+ * Page object for managing teams and departments.
+ */
+class TeamsPage {
+  /** @param {import('@playwright/test').Page} page */
+  constructor(page) {
+    this.page = page;
+  }
+
+  /** Navigate to the Teams section. */
+  async open() {
+    logger.log('Navigate to teams section');
+    await this.page.getByRole('link', { name: /teams/i }).click();
+  }
+
+  /**
+   * Add a new department via the plus icon.
+   * @param {string} name - Department name to create.
+   */
+  async addDepartment(name) {
+    logger.log('Open add department form');
+    await this.page.locator('#plus').click();
+    logger.log(`Fill department name with "${name}"`);
+    await this.page.locator('#departmentName, #depatmentName').fill(name);
+    logger.log('Submit new department');
+    await this.page.locator('#submit_add_department').click();
+  }
+}
+
+module.exports = { TeamsPage };

--- a/playwright/testdata/index.js
+++ b/playwright/testdata/index.js
@@ -51,6 +51,9 @@ module.exports = {
       narrative: 'Withdrawing Fund',
     },
   },
+  teams: {
+    departmentName: 'Marketing',
+  },
   company: {
     password: 'xpendless@A1',
     addressLine1: '123 Verification St',

--- a/playwright/tests/teams.spec.js
+++ b/playwright/tests/teams.spec.js
@@ -1,0 +1,19 @@
+const { test, expect } = require('../test-hooks');
+const { LoginPage } = require('../pages/login-page');
+const { TeamsPage } = require('../pages/teams-page');
+const testData = require('../testdata');
+
+// Validate creating a new department from the Teams page
+// This test logs in, opens Teams, adds a department and expects a success toast
+// then logs out.
+test('create department via teams plus icon', async ({ page, context }) => {
+  const loginPage = new LoginPage(page, context);
+  await loginPage.login(testData.credentials.email, testData.credentials.password);
+
+  const teams = new TeamsPage(page);
+  await teams.open();
+  await teams.addDepartment(testData.teams.departmentName);
+  await expect(page.locator('.Toastify__toast--success')).toBeVisible();
+
+  await loginPage.logout();
+});


### PR DESCRIPTION
## Summary
- add Teams page object to support department management
- add test for creating a new department via Teams plus icon
- store department test data in shared testdata module

## Testing
- `npm test dev` *(fails: browserType.launch executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_6893e03e03508327b52953052b6c6189