### PR TITLE
feat: verify department creation notification

### DIFF
--- a/playwright/pages/teams-page.js
+++ b/playwright/pages/teams-page.js
@@ -25,7 +25,7 @@ class TeamsPage {
     logger.log(`Fill department name with "${name}"`);
     await this.page.locator('#departmentName, #depatmentName').fill(name);
     logger.log('Submit new department');
-    await this.page.locator('#submit_add_department').click();
+    await this.page.getByRole('button', { name: 'Add' }).click();
   }
 }
 

--- a/playwright/tests/teams.spec.js
+++ b/playwright/tests/teams.spec.js
@@ -13,7 +13,10 @@ test('create department via teams plus icon', async ({ page, context }) => {
   const teams = new TeamsPage(page);
   await teams.open();
   await teams.addDepartment(testData.teams.departmentName);
-  await expect(page.locator('.Toastify__toast--success')).toBeVisible();
+  const successToast = page.locator('.Toastify__toast--success');
+  await expect(successToast).toBeVisible();
+  await expect(successToast).toContainText(/department/i);
+  await expect(page.getByText(testData.teams.departmentName)).toBeVisible();
 
   await loginPage.logout();
 });


### PR DESCRIPTION
## Summary
- ensure Teams page clicks the Add button by role
- assert marketing department creation with success notification

## Testing
- `npm test staging -- tests/teams.spec.js` *(fails: Please enter OTP character 1)*

------
https://chatgpt.com/codex/tasks/task_e_6893e83b03d08327bdb9adcad457a05d