### PR TITLE
Repeat department creation test with additional names

### DIFF
--- a/playwright/tests/teams.spec.js
+++ b/playwright/tests/teams.spec.js
@@ -3,20 +3,29 @@ const { LoginPage } = require('../pages/login-page');
 const { TeamsPage } = require('../pages/teams-page');
 const testData = require('../testdata');
 
-// Validate creating a new department from the Teams page
-// This test logs in, opens Teams, adds a department and expects a success toast
-// then logs out.
-test('create department via teams plus icon', async ({ page, context }) => {
-  const loginPage = new LoginPage(page, context);
-  await loginPage.login(testData.credentials.email, testData.credentials.password);
+// Validate creating new departments from the Teams page
+// This suite logs in, opens Teams, adds a department and expects a success toast
+// then logs out for each department name.
 
-  const teams = new TeamsPage(page);
-  await teams.open();
-  await teams.addDepartment(testData.teams.departmentName);
-  const successToast = page.locator('.Toastify__toast--success');
-  await expect(successToast).toBeVisible();
-  await expect(successToast).toContainText(/department/i);
-  await expect(page.getByText(testData.teams.departmentName)).toBeVisible();
+const departmentNames = [
+  testData.teams.departmentName,
+  'HR',
+  'Development',
+];
 
-  await loginPage.logout();
-});
+for (const name of departmentNames) {
+  test(`create department via teams plus icon - ${name}`, async ({ page, context }) => {
+    const loginPage = new LoginPage(page, context);
+    await loginPage.login(testData.credentials.email, testData.credentials.password);
+
+    const teams = new TeamsPage(page);
+    await teams.open();
+    await teams.addDepartment(name);
+    const successToast = page.locator('.Toastify__toast--success');
+    await expect(successToast).toBeVisible();
+    await expect(successToast).toContainText(/department/i);
+    await expect(page.getByText(name)).toBeVisible();
+
+    await loginPage.logout();
+  });
+}


### PR DESCRIPTION
## Summary
- iterate department creation test over Marketing, HR, and Development names to verify success each time

## Testing
- `npm test dev -- --project=chromium tests/teams.spec.js` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6893ece7bb14832783dce0db8fe33b3c