### PR TITLE
Persist credentials after company signup

### DIFF
--- a/playwright/pages/company-registration-page.js
+++ b/playwright/pages/company-registration-page.js
@@ -118,6 +118,9 @@ class CompanyRegistrationPage {
     await skipButton.click();
 
     await this.page.getByRole('link', { name: /dashboard/i }).waitFor();
+
+    // Persist the newly created admin credentials so subsequent tests can reuse them
+    testData.updateCredentials(email, password);
   }
 }
 

--- a/playwright/tests/company-registration.spec.js
+++ b/playwright/tests/company-registration.spec.js
@@ -31,9 +31,6 @@ test.describe.serial('company onboarding', () => {
     // debugger;
     await verifyPage.completeVerification();
 
-    // Use the newly created admin account for subsequent tests
-    testData.updateCredentials(regPage.email, testData.company.password);
-
     // After verification steps navigate to the Odoo staging environment
     const odoo = new OdooPage(page);
     await odoo.goto();


### PR DESCRIPTION
## Summary
- Automatically save newly created admin credentials at the end of the company registration flow
- Simplify company onboarding test by relying on the registration page to persist credentials

## Testing
- `npm test staging -- tests/company-registration.spec.js --project=chromium --max-failures=1` *(fails: TypeError: Cannot read properties of undefined (reading 'close'))*

------
https://chatgpt.com/codex/tasks/task_e_6893ed8fac9083279f0ee9107c812daf