### PR TITLE
test: verify department success message

### DIFF
--- a/playwright/tests/teams.spec.js
+++ b/playwright/tests/teams.spec.js
@@ -5,7 +5,8 @@ const testData = require('../testdata');
 
 // Validate creating new departments from the Teams page
 // This suite logs in, opens Teams, adds a department and expects a success toast
-// then logs out for each department name.
+// message "Department created successfully!" then logs out for each department
+// name.
 
 const departmentNames = [
   testData.teams.departmentName,
@@ -23,7 +24,7 @@ for (const name of departmentNames) {
     await teams.addDepartment(name);
     const successToast = page.locator('.Toastify__toast--success');
     await successToast.waitFor({ state: 'visible' });
-    await expect(successToast).toContainText(/department/i);
+    await expect(successToast).toHaveText('Department created successfully!');
     await expect(page.getByText(name)).toBeVisible();
 
     await loginPage.logout();


### PR DESCRIPTION
## Summary
- check toast for exact message "Department created successfully!" when adding departments
- document full message in teams test comments

## Testing
- `npm test dev` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689476764860832780605bbcd3ad730a