### PR TITLE
Filter success toast in Teams tests

### DIFF
--- a/playwright/tests/teams.spec.js
+++ b/playwright/tests/teams.spec.js
@@ -22,7 +22,10 @@ for (const name of departmentNames) {
     const teams = new TeamsPage(page);
     await teams.open();
     await teams.addDepartment(name);
-    const successToast = page.locator('.Toastify__toast--success');
+    const successToast = page
+      .locator('.Toastify__toast--success')
+      .filter({ hasText: 'Department created successfully!' })
+      .first();
     await successToast.waitFor({ state: 'visible' });
     await expect(successToast).toHaveText('Department created successfully!');
     await expect(page.getByText(name)).toBeVisible();


### PR DESCRIPTION
## Summary
- filter the Teams success toast by expected text to avoid strict mode errors when previous toasts linger

## Testing
- `npx playwright test tests/teams.spec.js --project=chromium` *(fails: host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6894797aebc88327916b2a8e608a8205