### PR TITLE
Skip non-required tests and add user creation suite

### DIFF
--- a/playwright/pages/users-page.js
+++ b/playwright/pages/users-page.js
@@ -1,0 +1,66 @@
+const { faker } = require('@faker-js/faker');
+const logger = require('../logger');
+
+/**
+ * Page object for managing application users.
+ */
+class UsersPage {
+  /** @param {import('@playwright/test').Page} page */
+  constructor(page) {
+    this.page = page;
+  }
+
+  /** Navigate to the Users section. */
+  async open() {
+    logger.log('Navigate to users section');
+    await this.page.getByRole('link', { name: /users/i }).click();
+  }
+
+  /**
+   * Generate a random number with the given length using faker.
+   * @param {number} length
+   * @returns {string}
+   */
+  static randomDigits(length) {
+    return faker.number.int({
+      min: 10 ** (length - 1),
+      max: 10 ** length - 1,
+    }).toString();
+  }
+
+  /**
+   * Add a new user via the Add User form.
+   * @param {object} user
+   * @param {string} user.firstName
+   * @param {string} user.lastName
+   * @param {string} user.email
+   * @param {string} user.role
+   */
+  async addUser({ firstName, lastName, email, role }) {
+    logger.log('Open add user form');
+    await this.page.getByRole('button', { name: /add user/i }).click();
+
+    logger.log(`Fill first name with "${firstName}"`);
+    await this.page.getByLabel(/first name/i).fill(firstName);
+    logger.log(`Fill last name with "${lastName}"`);
+    await this.page.getByLabel(/last name/i).fill(lastName);
+    logger.log(`Fill email with "${email}"`);
+    await this.page.getByLabel(/email/i).fill(email);
+
+    const mobile = UsersPage.randomDigits(10);
+    logger.log(`Fill mobile number with "${mobile}"`);
+    await this.page.getByLabel(/mobile number/i).fill(mobile);
+
+    const nationalId = UsersPage.randomDigits(11);
+    logger.log(`Fill national ID with "${nationalId}"`);
+    await this.page.getByLabel(/national id/i).fill(nationalId);
+
+    logger.log(`Select role ${role}`);
+    await this.page.getByLabel(/role/i).selectOption({ label: role });
+
+    logger.log('Submit new user form');
+    await this.page.getByRole('button', { name: /create|add|submit/i }).click();
+  }
+}
+
+module.exports = { UsersPage };

--- a/playwright/tests/login.spec.js
+++ b/playwright/tests/login.spec.js
@@ -3,14 +3,14 @@ const { LoginPage } = require('../pages/login-page');
 const testData = require('../testdata');
 
 // Verify that a user can log into the application
-test('login with OTP', async ({ page, context }) => {
+test.skip('login with OTP', async ({ page, context }) => {
   const loginPage = new LoginPage(page, context);
   await loginPage.login(testData.credentials.email, testData.credentials.password);
   await expect(page.getByRole('link', { name: /dashboard/i })).toBeVisible();
 });
 
 // Ensure that the logout functionality works
-test('logout via icon', async ({ page, context }) => {
+test.skip('logout via icon', async ({ page, context }) => {
   const loginPage = new LoginPage(page, context);
   await loginPage.login(testData.credentials.email, testData.credentials.password);
   await loginPage.logout();

--- a/playwright/tests/pettycash.spec.js
+++ b/playwright/tests/pettycash.spec.js
@@ -4,7 +4,7 @@ const { PettyCashPage } = require('../pages/petty-cash-page');
 const testData = require('../testdata');
 
 // Validate adding money to petty cash
-test('petty cash add cash', async ({ page, context }) => {
+test.skip('petty cash add cash', async ({ page, context }) => {
   const loginPage = new LoginPage(page, context);
   await loginPage.login(testData.credentials.email, testData.credentials.password);
 
@@ -17,7 +17,7 @@ test('petty cash add cash', async ({ page, context }) => {
 });
 
 // Validate withdrawing money from petty cash
-test('petty cash withdraw cash', async ({ page, context }) => {
+test.skip('petty cash withdraw cash', async ({ page, context }) => {
   const loginPage = new LoginPage(page, context);
   await loginPage.login(testData.credentials.email, testData.credentials.password);
 

--- a/playwright/tests/user-creation.spec.js
+++ b/playwright/tests/user-creation.spec.js
@@ -1,0 +1,28 @@
+const { test, expect } = require('../test-hooks');
+const { LoginPage } = require('../pages/login-page');
+const { UsersPage } = require('../pages/users-page');
+const { faker } = require('@faker-js/faker');
+const testData = require('../testdata');
+
+// Execute user creation for multiple roles
+const roles = ['Admin', 'Accountant', 'Card Holder'];
+
+for (const role of roles) {
+  test(`create user - ${role}`, async ({ page, context }) => {
+    const loginPage = new LoginPage(page, context);
+    await loginPage.login(testData.credentials.email, testData.credentials.password);
+
+    const users = new UsersPage(page);
+    await users.open();
+    await users.addUser({
+      firstName: faker.person.firstName().replace(/[^a-zA-Z]/g, ''),
+      lastName: faker.person.lastName().replace(/[^a-zA-Z]/g, ''),
+      email: `${faker.string.alpha({ length: 8 }).toLowerCase()}@yopmail.com`,
+      role,
+    });
+
+    await expect(page.locator('.Toastify__toast--success')).toBeVisible();
+
+    await loginPage.logout();
+  });
+}

--- a/playwright/tests/wallet.spec.js
+++ b/playwright/tests/wallet.spec.js
@@ -4,7 +4,7 @@ const { WalletPage } = require('../pages/wallet-page');
 const testData = require('../testdata');
 
 // Test adding funds to the company wallet
-test('company wallet add funds', async ({ page, context }) => {
+test.skip('company wallet add funds', async ({ page, context }) => {
   const loginPage = new LoginPage(page, context);
   await loginPage.login(testData.credentials.email, testData.credentials.password);
 
@@ -17,7 +17,7 @@ test('company wallet add funds', async ({ page, context }) => {
 });
 
 // Test withdrawing funds from the company wallet
-test('company wallet withdraw funds', async ({ page, context }) => {
+test.skip('company wallet withdraw funds', async ({ page, context }) => {
   const loginPage = new LoginPage(page, context);
   await loginPage.login(testData.credentials.email, testData.credentials.password);
 


### PR DESCRIPTION
## Summary
- skip login, petty cash, and wallet tests so they no longer run
- add User Creation tests for Admin, Accountant, and Card Holder roles
- implement UsersPage object to support user form interactions

## Testing
- `npm test dev` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/webkit-2158/pw_run.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68947ee6d16c8327b8ad25496c223f7a