### PR TITLE
Fix user creation test to select mandatory fields

### DIFF
--- a/playwright/pages/users-page.js
+++ b/playwright/pages/users-page.js
@@ -33,10 +33,13 @@ class UsersPage {
    * @param {object} user
    * @param {string} user.firstName
    * @param {string} user.lastName
-   * @param {string} user.email
-   * @param {string} user.role
+  * @param {string} user.email
+  * @param {string} user.role
+  * @param {string} [user.department]
+  * @param {string} [user.gender]
+  * @param {string} [user.nationality]
    */
-  async addUser({ firstName, lastName, email, role }) {
+  async addUser({ firstName, lastName, email, role, department = 'Marketing', gender = 'Male', nationality = 'Kenyan' }) {
     logger.log('Open add user form');
     await this.page.getByRole('button', { name: /add user/i }).click();
 
@@ -54,6 +57,15 @@ class UsersPage {
     const nationalId = UsersPage.randomDigits(11);
     logger.log(`Fill national ID with "${nationalId}"`);
     await this.page.getByLabel(/national id/i).fill(nationalId);
+
+    logger.log(`Select department ${department}`);
+    await this.page.getByLabel(/department/i).selectOption({ label: department });
+
+    logger.log(`Select gender ${gender}`);
+    await this.page.getByLabel(/gender/i).selectOption({ label: gender });
+
+    logger.log(`Select nationality ${nationality}`);
+    await this.page.getByLabel(/nationality/i).selectOption({ label: nationality });
 
     logger.log(`Select role ${role}`);
     await this.page.getByLabel(/role/i).selectOption({ label: role });

--- a/playwright/tests/user-creation.spec.js
+++ b/playwright/tests/user-creation.spec.js
@@ -19,6 +19,9 @@ for (const role of roles) {
       lastName: faker.person.lastName().replace(/[^a-zA-Z]/g, ''),
       email: `${faker.string.alpha({ length: 8 }).toLowerCase()}@yopmail.com`,
       role,
+      department: testData.teams.departmentName,
+      gender: 'Male',
+      nationality: 'Kenyan',
     });
 
     await expect(page.locator('.Toastify__toast--success')).toBeVisible();


### PR DESCRIPTION
## Summary
- extend UsersPage to select department, gender, nationality and role
- supply department, gender and nationality in user creation test

## Testing
- `npm test dev -- --list`
- `npm test dev tests/user-creation.spec.js -- --project=chromium --reporter=line` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68948742ba988327990f1f5ff438d269