### PR TITLE
feat: validate phone length and role toggles

### DIFF
--- a/playwright/pages/users-page.js
+++ b/playwright/pages/users-page.js
@@ -74,17 +74,19 @@ class UsersPage {
   }
 
   /**
-   * Add a new user via the Add User form.
-   * @param {object} user
-   * @param {string} user.firstName
-   * @param {string} user.lastName
+  * Add a new user via the Add User form.
+  * @param {object} user
+  * @param {string} user.firstName
+  * @param {string} user.lastName
   * @param {string} user.email
   * @param {string} user.role
   * @param {string} [user.department]
   * @param {string} [user.gender]
   * @param {string} [user.nationality]
+  * @param {string} [user.mobile] - Optional mobile number. If omitted a random
+  *   value between 8 and 9 digits will be generated.
    */
-  async addUser({ firstName, lastName, email, role, department = 'Marketing', gender = 'Male', nationality = 'Kenyan' }) {
+  async addUser({ firstName, lastName, email, role, department = 'Marketing', gender = 'Male', nationality = 'Kenyan', mobile }) {
     logger.log('Open add user form');
     await this.page.getByRole('button', { name: /add user/i }).click();
 
@@ -95,9 +97,10 @@ class UsersPage {
     logger.log(`Fill email with "${email}"`);
     await this.page.getByLabel(/email/i).fill(email);
 
-    const mobile = UsersPage.randomDigits(10);
-    logger.log(`Fill mobile number with "${mobile}"`);
-    await this.page.getByLabel(/mobile number/i).fill(mobile);
+    const mobileLength = mobile?.length ?? faker.number.int({ min: 8, max: 9 });
+    const mobileNumber = mobile ?? UsersPage.randomDigits(mobileLength);
+    logger.log(`Fill mobile number with "${mobileNumber}"`);
+    await this.page.getByLabel(/mobile number/i).fill(mobileNumber);
 
     const nationalId = UsersPage.randomDigits(11);
     logger.log(`Fill national ID with "${nationalId}"`);
@@ -112,8 +115,17 @@ class UsersPage {
     logger.log(`Select nationality ${nationality}`);
     await this.selectFromDropdown(/nationality/i, nationality);
 
-    logger.log(`Select role ${role}`);
-    await this.selectFromDropdown(/role/i, role);
+    logger.log(`Set role ${role}`);
+    const roleLower = role.toLowerCase();
+    if (roleLower.includes('admin')) {
+      await this.page.getByLabel(/admin/i).check();
+    }
+    if (roleLower.includes('accountant')) {
+      await this.page.getByLabel(/accountant/i).check();
+    }
+    if (roleLower.includes('card holder')) {
+      await this.page.getByLabel(/card holder/i).check();
+    }
 
     logger.log('Submit new user form');
     await this.page.getByRole('button', { name: /create|add|submit/i }).click();

--- a/playwright/tests/user-creation.spec.js
+++ b/playwright/tests/user-creation.spec.js
@@ -6,6 +6,11 @@ const testData = require('../testdata');
 
 // Execute user creation for multiple roles
 const roles = ['Admin', 'Accountant', 'Card Holder'];
+const mobileMap = {
+  Admin: UsersPage.randomDigits(9),
+  Accountant: UsersPage.randomDigits(8),
+  'Card Holder': UsersPage.randomDigits(9),
+};
 
 for (const role of roles) {
   test(`create user - ${role}`, async ({ page, context }) => {
@@ -19,6 +24,7 @@ for (const role of roles) {
       lastName: faker.person.lastName().replace(/[^a-zA-Z]/g, ''),
       email: `${faker.string.alpha({ length: 8 }).toLowerCase()}@yopmail.com`,
       role,
+      mobile: mobileMap[role],
       department: testData.teams.departmentName,
       gender: 'Male',
       nationality: 'Kenyan',


### PR DESCRIPTION
## Summary
- generate 8-9 digit mobile numbers when adding a user
- set Admin/Accountant switches and Card Holder checkbox based on role
- pass explicit mobile numbers to user creation tests

## Testing
- `npm test dev` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1169/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_6895f9d6c55483278a4a2affec7eab4c