### PR TITLE
Handle duplicate plus buttons and select user roles correctly

### DIFF
--- a/playwright/pages/teams-page.js
+++ b/playwright/pages/teams-page.js
@@ -21,7 +21,10 @@ class TeamsPage {
    */
   async addDepartment(name) {
     logger.log('Open add department form');
-    await this.page.locator('#plus').click();
+    // Multiple elements share the same invalid id of "plus". Always
+    // target the first occurrence to avoid strict mode errors when the
+    // locator matches more than one element.
+    await this.page.locator('#plus').first().click();
     logger.log(`Fill department name with "${name}"`);
     await this.page.locator('#departmentName, #depatmentName').fill(name);
     logger.log('Submit new department');

--- a/playwright/pages/users-page.js
+++ b/playwright/pages/users-page.js
@@ -117,12 +117,27 @@ class UsersPage {
 
     logger.log(`Set role ${role}`);
     const roleLower = role.toLowerCase();
+
+    // Admin and Accountant roles use toggle switches instead of checkboxes.
+    // Attempt to interact with a switch control first, falling back to a
+    // label click if the switch is not found.
     if (roleLower.includes('admin')) {
-      await this.page.getByLabel(/admin/i).check();
+      const adminSwitch = this.page.getByRole('switch', { name: /admin/i });
+      if (await adminSwitch.count()) {
+        await adminSwitch.click();
+      } else {
+        await this.page.getByLabel(/admin/i).click();
+      }
     }
     if (roleLower.includes('accountant')) {
-      await this.page.getByLabel(/accountant/i).check();
+      const accountantSwitch = this.page.getByRole('switch', { name: /accountant/i });
+      if (await accountantSwitch.count()) {
+        await accountantSwitch.click();
+      } else {
+        await this.page.getByLabel(/accountant/i).click();
+      }
     }
+    // Card Holder role uses a traditional checkbox.
     if (roleLower.includes('card holder')) {
       await this.page.getByLabel(/card holder/i).check();
     }

--- a/playwright/tests/user-creation.spec.js
+++ b/playwright/tests/user-creation.spec.js
@@ -11,6 +11,11 @@ const mobileMap = {
   Accountant: UsersPage.randomDigits(8),
   'Card Holder': UsersPage.randomDigits(9),
 };
+const lastNameMap = {
+  Admin: 'Admin',
+  Accountant: 'Accountant',
+  'Card Holder': 'Card Holder',
+};
 
 for (const role of roles) {
   test(`create user - ${role}`, async ({ page, context }) => {
@@ -21,7 +26,8 @@ for (const role of roles) {
     await users.open();
     await users.addUser({
       firstName: faker.person.firstName().replace(/[^a-zA-Z]/g, ''),
-      lastName: faker.person.lastName().replace(/[^a-zA-Z]/g, ''),
+      // Last name must correspond to the selected role
+      lastName: lastNameMap[role],
       email: `${faker.string.alpha({ length: 8 }).toLowerCase()}@yopmail.com`,
       role,
       mobile: mobileMap[role],


### PR DESCRIPTION
## Summary
- Target first `#plus` element to avoid strict mode violations when adding departments
- Map user last names to their roles and ensure proper role selection via switches or checkbox

## Testing
- `npm test dev` *(fails: 15 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689602ab8c40832785e974952f559e60