### PR TITLE
Use click for Admin/Accountant role toggles

### DIFF
--- a/playwright/pages/users-page.js
+++ b/playwright/pages/users-page.js
@@ -92,7 +92,12 @@ class UsersPage {
     // Try a simple label lookup first which covers standard checkboxes
     const labelledControl = this.page.getByLabel(roleRegex);
     if (await labelledControl.count()) {
-      await labelledControl.check({ force: true });
+      const checked =
+        (await labelledControl.getAttribute('aria-checked')) === 'true' ||
+        (await labelledControl.evaluate(node => node.checked ?? false));
+      if (!checked) {
+        await labelledControl.click({ force: true });
+      }
       return;
     }
 
@@ -109,7 +114,10 @@ class UsersPage {
     // Fallback to a role based checkbox
     const checkboxControl = this.page.getByRole('checkbox', { name: roleRegex });
     if (await checkboxControl.count()) {
-      await checkboxControl.check({ force: true });
+      const checked = await checkboxControl.isChecked();
+      if (!checked) {
+        await checkboxControl.click();
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- ensure role toggles are activated via click when labels are present
- avoid toggling already-enabled checkboxes by checking state before clicking

## Testing
- `npm test dev -- --project=chromium` *(fails: company registration, teams creation, user creation Admin; user creation Accountant interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6897e847e66083279858995679279ba5