### PR TITLE
Persist updated credentials

### DIFF
--- a/playwright/testdata/index.js
+++ b/playwright/testdata/index.js
@@ -24,6 +24,7 @@ module.exports = {
     if (password) this.credentials.password = password;
     try {
       fs.writeFileSync(credPath, JSON.stringify(this.credentials));
+      storedCreds = { ...this.credentials };
     } catch {
       // ignore file write errors
     }


### PR DESCRIPTION
## Summary
- Update testdata credential updater to persist runtime email and password

## Testing
- `npx playwright install`
- `npx playwright install-deps`
- `npm test dev` *(fails: company onboarding, teams, user-creation tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689eb86b80d883278beeb72c0649c5dd