### PR TITLE
Skip non-registration tests and add tax codes spec

### DIFF
--- a/playwright/pages/tax-codes-page.js
+++ b/playwright/pages/tax-codes-page.js
@@ -1,0 +1,49 @@
+const logger = require('../logger');
+
+/**
+ * Page object for managing tax codes within Settings > Accounting.
+ */
+class TaxCodesPage {
+  /** @param {import('@playwright/test').Page} page */
+  constructor(page) {
+    this.page = page;
+  }
+
+  /** Navigate to the Tax Codes section via Settings and Accounting tabs. */
+  async open() {
+    logger.log('Navigate to settings');
+    await this.page.getByRole('link', { name: /settings/i }).click();
+    logger.log('Open accounting tab');
+    await this.page.getByRole('link', { name: /accounting/i }).click();
+    logger.log('Open tax codes section');
+    await this.page.getByRole('link', { name: /tax codes/i }).click();
+  }
+
+  /**
+   * Add a new tax code.
+   * @param {string} name - Name of the tax code.
+   * @param {string|number} rate - Percentage rate for the tax code.
+   */
+  async addTaxCode(name, rate) {
+    logger.log('Open add tax code form');
+    await this.page.getByRole('button', { name: /add new tax/i }).click();
+    logger.log(`Fill tax code name with "${name}"`);
+    await this.page.getByLabel(/tax name/i).fill(name);
+    logger.log(`Fill tax rate with "${rate}"`);
+    await this.page.getByLabel(/tax rate/i).fill(String(rate));
+    logger.log('Submit new tax code');
+    await this.page.getByRole('button', { name: /^add$/i }).click();
+  }
+
+  /**
+   * Locate a tax code row by name.
+   * @param {string} name - Tax code name to search for.
+   * @returns {import('@playwright/test').Locator} Locator for the row.
+   */
+  findTaxCodeRow(name) {
+    logger.log(`Locate tax code row for "${name}"`);
+    return this.page.getByRole('row', { name: new RegExp(name, 'i') });
+  }
+}
+
+module.exports = { TaxCodesPage };

--- a/playwright/testdata/index.js
+++ b/playwright/testdata/index.js
@@ -55,6 +55,10 @@ module.exports = {
   teams: {
     departmentName: 'Marketing',
   },
+  taxCode: {
+    name: 'FBR',
+    rate: '40',
+  },
   company: {
     password: 'xpendless@A1',
     addressLine1: '123 Verification St',

--- a/playwright/tests/tax-codes.spec.js
+++ b/playwright/tests/tax-codes.spec.js
@@ -1,0 +1,21 @@
+const { test, expect } = require('../test-hooks');
+const { LoginPage } = require('../pages/login-page');
+const { TaxCodesPage } = require('../pages/tax-codes-page');
+const testData = require('../testdata');
+
+// Validate adding a new tax code under Settings > Accounting
+// Skipped by default until the feature is ready for testing
+test.skip('add new tax code', async ({ page, context }) => {
+  const loginPage = new LoginPage(page, context);
+  await loginPage.login(testData.credentials.email, testData.credentials.password);
+
+  const taxCodes = new TaxCodesPage(page);
+  await taxCodes.open();
+  await taxCodes.addTaxCode(testData.taxCode.name, testData.taxCode.rate);
+
+  const row = taxCodes.findTaxCodeRow(testData.taxCode.name);
+  await expect(row).toContainText(testData.taxCode.name);
+  await expect(row).toContainText(`${testData.taxCode.rate}`);
+
+  await loginPage.logout();
+});

--- a/playwright/tests/teams.spec.js
+++ b/playwright/tests/teams.spec.js
@@ -13,7 +13,7 @@ const departmentNames = [
   'Development',
 ];
 
-test('create multiple departments via teams plus icon', async ({ page, context }) => {
+test.skip('create multiple departments via teams plus icon', async ({ page, context }) => {
   const loginPage = new LoginPage(page, context);
   await loginPage.login(testData.credentials.email, testData.credentials.password);
 

--- a/playwright/tests/user-creation.spec.js
+++ b/playwright/tests/user-creation.spec.js
@@ -17,7 +17,7 @@ const lastNameMap = {
   'Card Holder': 'Card Holder',
 };
 
-test('create users for all roles', async ({ page, context }) => {
+test.skip('create users for all roles', async ({ page, context }) => {
   const loginPage = new LoginPage(page, context);
   await loginPage.login(
     testData.credentials.email,


### PR DESCRIPTION
## Summary
- Skip all existing tests except company registration
- Add tax code page object and test for adding tax codes

## Testing
- `npm test staging -- --reporter=line` *(fails: browserType.launch: Executable doesn't exist at ...; run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_689fed5b9e6083278d757debce8f7bb7