### PR TITLE
Run related tests in shared login session

### DIFF
--- a/playwright/tests/login.spec.js
+++ b/playwright/tests/login.spec.js
@@ -2,17 +2,35 @@ const { test, expect } = require('../test-hooks');
 const { LoginPage } = require('../pages/login-page');
 const testData = require('../testdata');
 
-// Verify that a user can log into the application
-test.skip('login with OTP', async ({ page, context }) => {
-  const loginPage = new LoginPage(page, context);
-  await loginPage.login(testData.credentials.email, testData.credentials.password);
-  await expect(page.getByRole('link', { name: /dashboard/i })).toBeVisible();
+// Use a single login session for both login and logout tests.
+test.describe.serial('login flow', () => {
+  /** @type {import('@playwright/test').BrowserContext} */
+  let context;
+  /** @type {import('@playwright/test').Page} */
+  let page;
+  /** @type {LoginPage} */
+  let loginPage;
+
+  test.beforeAll(async ({ browser }) => {
+    context = await browser.newContext();
+    page = await context.newPage();
+    loginPage = new LoginPage(page, context);
+    await loginPage.login(testData.credentials.email, testData.credentials.password);
+  });
+
+  test.afterAll(async () => {
+    await context.close();
+  });
+
+  // Verify that a user can log into the application
+  test('login with OTP', async () => {
+    await expect(page.getByRole('link', { name: /dashboard/i })).toBeVisible();
+  });
+
+  // Ensure that the logout functionality works
+  test('logout via icon', async () => {
+    await loginPage.logout();
+    await expect(page.getByLabel('Email address')).toBeVisible();
+  });
 });
 
-// Ensure that the logout functionality works
-test.skip('logout via icon', async ({ page, context }) => {
-  const loginPage = new LoginPage(page, context);
-  await loginPage.login(testData.credentials.email, testData.credentials.password);
-  await loginPage.logout();
-  await expect(page.getByLabel('Email address')).toBeVisible();
-});

--- a/playwright/tests/pettycash.spec.js
+++ b/playwright/tests/pettycash.spec.js
@@ -3,28 +3,42 @@ const { LoginPage } = require('../pages/login-page');
 const { PettyCashPage } = require('../pages/petty-cash-page');
 const testData = require('../testdata');
 
-// Validate adding money to petty cash
-test.skip('petty cash add cash', async ({ page, context }) => {
-  const loginPage = new LoginPage(page, context);
-  await loginPage.login(testData.credentials.email, testData.credentials.password);
+// Run petty cash add and withdraw in a single login session.
+test.describe.serial('petty cash', () => {
+  /** @type {import('@playwright/test').BrowserContext} */
+  let context;
+  /** @type {import('@playwright/test').Page} */
+  let page;
+  /** @type {LoginPage} */
+  let loginPage;
+  /** @type {PettyCashPage} */
+  let pettyCash;
 
-  const pettyCash = new PettyCashPage(page);
-  await pettyCash.open();
-  await pettyCash.addCash(testData.pettyCash.add.amount, testData.pettyCash.add.description);
-  await expect(page.locator('.Toastify__toast--success')).toBeVisible();
+  test.beforeAll(async ({ browser }) => {
+    context = await browser.newContext();
+    page = await context.newPage();
+    loginPage = new LoginPage(page, context);
+    await loginPage.login(testData.credentials.email, testData.credentials.password);
+    pettyCash = new PettyCashPage(page);
+  });
 
-  await loginPage.logout();
+  test.afterAll(async () => {
+    await loginPage.logout();
+    await context.close();
+  });
+
+  // Validate adding money to petty cash
+  test('add cash', async () => {
+    await pettyCash.open();
+    await pettyCash.addCash(testData.pettyCash.add.amount, testData.pettyCash.add.description);
+    await expect(page.locator('.Toastify__toast--success')).toBeVisible();
+  });
+
+  // Validate withdrawing money from petty cash
+  test('withdraw cash', async () => {
+    await pettyCash.open();
+    await pettyCash.withdrawCash(testData.pettyCash.withdraw.amount, testData.pettyCash.withdraw.description);
+    await expect(page.locator('.Toastify__toast--success')).toBeVisible();
+  });
 });
 
-// Validate withdrawing money from petty cash
-test.skip('petty cash withdraw cash', async ({ page, context }) => {
-  const loginPage = new LoginPage(page, context);
-  await loginPage.login(testData.credentials.email, testData.credentials.password);
-
-  const pettyCash = new PettyCashPage(page);
-  await pettyCash.open();
-  await pettyCash.withdrawCash(testData.pettyCash.withdraw.amount, testData.pettyCash.withdraw.description);
-  await expect(page.locator('.Toastify__toast--success')).toBeVisible();
-
-  await loginPage.logout();
-});

--- a/playwright/tests/wallet.spec.js
+++ b/playwright/tests/wallet.spec.js
@@ -3,28 +3,42 @@ const { LoginPage } = require('../pages/login-page');
 const { WalletPage } = require('../pages/wallet-page');
 const testData = require('../testdata');
 
-// Test adding funds to the company wallet
-test.skip('company wallet add funds', async ({ page, context }) => {
-  const loginPage = new LoginPage(page, context);
-  await loginPage.login(testData.credentials.email, testData.credentials.password);
+// Run wallet add and withdraw in a single login session.
+test.describe.serial('wallet', () => {
+  /** @type {import('@playwright/test').BrowserContext} */
+  let context;
+  /** @type {import('@playwright/test').Page} */
+  let page;
+  /** @type {LoginPage} */
+  let loginPage;
+  /** @type {WalletPage} */
+  let wallet;
 
-  const wallet = new WalletPage(page);
-  await wallet.open();
-  await wallet.addFunds(testData.wallet.add.amount, testData.wallet.add.narrative);
-  await expect(page.getByText(/Fund Added Successfully!/i)).toBeVisible();
+  test.beforeAll(async ({ browser }) => {
+    context = await browser.newContext();
+    page = await context.newPage();
+    loginPage = new LoginPage(page, context);
+    await loginPage.login(testData.credentials.email, testData.credentials.password);
+    wallet = new WalletPage(page);
+  });
 
-  await loginPage.logout();
+  test.afterAll(async () => {
+    await loginPage.logout();
+    await context.close();
+  });
+
+  // Test adding funds to the company wallet
+  test('add funds', async () => {
+    await wallet.open();
+    await wallet.addFunds(testData.wallet.add.amount, testData.wallet.add.narrative);
+    await expect(page.getByText(/Fund Added Successfully!/i)).toBeVisible();
+  });
+
+  // Test withdrawing funds from the company wallet
+  test('withdraw funds', async () => {
+    await wallet.open();
+    await wallet.withdrawFunds(testData.wallet.withdraw.amount, testData.wallet.withdraw.narrative);
+    await expect(page.getByText(/Fund Withdrawal Successful!/i)).toBeVisible();
+  });
 });
 
-// Test withdrawing funds from the company wallet
-test.skip('company wallet withdraw funds', async ({ page, context }) => {
-  const loginPage = new LoginPage(page, context);
-  await loginPage.login(testData.credentials.email, testData.credentials.password);
-
-  const wallet = new WalletPage(page);
-  await wallet.open();
-  await wallet.withdrawFunds(testData.wallet.withdraw.amount, testData.wallet.withdraw.narrative);
-  await expect(page.getByText(/Fund Withdrawal Successful!/i)).toBeVisible();
-
-  await loginPage.logout();
-});


### PR DESCRIPTION
## Summary
- run login and logout tests within a single authenticated session
- execute petty cash add and withdrawal without logging in twice
- run wallet add and withdraw tests using one login session

## Testing
- `node run-tests.js dev tests/login.spec.js tests/pettycash.spec.js tests/wallet.spec.js --project=chromium` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f5cccaa08327ba3c1eab7d377edf