### PR TITLE
Wait for tax code success notification to disappear

### DIFF
--- a/playwright/tests/tax-codes.spec.js
+++ b/playwright/tests/tax-codes.spec.js
@@ -13,6 +13,10 @@ test.skip('add new tax code', async ({ page, context }) => {
   await taxCodes.open();
   await taxCodes.addTaxCode(testData.taxCode.name, testData.taxCode.rate);
 
+  const successToast = page.locator('.Toastify__toast--success');
+  await expect(successToast).toBeVisible();
+  await successToast.waitFor({ state: 'hidden' });
+
   const row = taxCodes.findTaxCodeRow(testData.taxCode.name);
   await expect(row).toContainText(testData.taxCode.name);
   await expect(row).toContainText(`${testData.taxCode.rate}`);


### PR DESCRIPTION
## Summary
- Assert success toast appears after adding a tax code and wait for it to dismiss before verifying entries

## Testing
- `npm test dev -- tests/tax-codes.spec.js --project=chromium`

------
https://chatgpt.com/codex/tasks/task_e_68a6f6d1f69883278f368d843f8a563c