### PR TITLE
Use single log file for test run

### DIFF
--- a/playwright/run-tests.js
+++ b/playwright/run-tests.js
@@ -11,6 +11,13 @@ if (!envName) {
 
 process.env.CURRENT_ENV = envName;
 
+// Create a unique log file path for this test run and expose it via the
+// environment so that every worker writes to the same file.
+const logsDir = path.join(__dirname, 'logs');
+fs.mkdirSync(logsDir, { recursive: true });
+const runTimestamp = new Date().toISOString().replace(/[:.]/g, '-');
+process.env.LOG_FILE = path.join(logsDir, `${runTimestamp}.log`);
+
 // Determine browser name from command line options. Default to chromium.
 let browser = 'chromium';
 for (const arg of args.slice(1)) {


### PR DESCRIPTION
## Summary
- Ensure all tests in a run append to a single log file
- Separate logs per test with a blank line and header of the test title
- Propagate log file path from run-tests so multiple workers share same file

## Testing
- `node run-tests.js dev tests/login.spec.js --project=chromium` *(fails: tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f77497e08327aa37c1d666c04000