### PR TITLE
Use single log file for all tests

### DIFF
--- a/playwright/logger.js
+++ b/playwright/logger.js
@@ -13,6 +13,7 @@ const defaultFile = path.join(
 );
 const filePath = process.env.LOG_FILE || defaultFile;
 let stream = fs.createWriteStream(filePath, { flags: 'a' });
+let isFirstTest = true;
 
 function start(testTitle) {
   if (!stream) {
@@ -20,9 +21,14 @@ function start(testTitle) {
     // run timestamp so all logs for this execution stay in one file.
     stream = fs.createWriteStream(filePath, { flags: 'a' });
   }
-  // Separate logs for different tests with a blank line and start each
-  // section with the test title.
-  stream.write(`\n${testTitle}\n`);
+  // Write the test title and ensure there's a blank line separating logs
+  // from different tests. Avoid a leading newline at the very top of the
+  // file so the first test title appears immediately.
+  if (!isFirstTest) {
+    stream.write('\n');
+  }
+  stream.write(`${testTitle}\n`);
+  isFirstTest = false;
 }
 
 function log(message) {

--- a/playwright/run-tests.js
+++ b/playwright/run-tests.js
@@ -16,7 +16,9 @@ process.env.CURRENT_ENV = envName;
 const logsDir = path.join(__dirname, 'logs');
 fs.mkdirSync(logsDir, { recursive: true });
 const runTimestamp = new Date().toISOString().replace(/[:.]/g, '-');
-process.env.LOG_FILE = path.join(logsDir, `${runTimestamp}.log`);
+// Expose a single log file path so all workers append to the same file.
+const logFile = path.join(logsDir, `${runTimestamp}.log`);
+process.env.LOG_FILE = logFile;
 
 // Determine browser name from command line options. Default to chromium.
 let browser = 'chromium';


### PR DESCRIPTION
## Summary
- ensure each test run writes to a single log file
- separate each test's logs with the test title and a blank line

## Testing
- `npm test dev -- tests/login.spec.js --reporter=list` *(fails: browserType.launch: Executable doesn't exist)*
- `npx playwright install` *(failed: aborted while downloading browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68a70013b5d88327b7e9dbef82a2f1de