### PR TITLE
Persist new credentials after company registration

### DIFF
--- a/playwright/testdata/index.js
+++ b/playwright/testdata/index.js
@@ -28,6 +28,22 @@ module.exports = {
     } catch {
       // ignore file write errors
     }
+    // also update this file so the defaults reflect the latest credentials
+    try {
+      const fileContent = fs
+        .readFileSync(__filename, 'utf8')
+        .replace(
+          /email: storedCreds.email \|\| '.*',/,
+          `email: storedCreds.email || '${this.credentials.email}',`
+        )
+        .replace(
+          /password: storedCreds.password \|\| '.*',/,
+          `password: storedCreds.password || '${this.credentials.password}',`
+        );
+      fs.writeFileSync(__filename, fileContent);
+    } catch {
+      // ignore file update errors
+    }
   },
   otp: {
     mobile: '123456',


### PR DESCRIPTION
## Summary
- update testdata to write updated login credentials back to index.js so defaults track the latest company

## Testing
- `npm test staging` *(fails: 15 failed, 6 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a70b0daf5c83278760e5f723307340