### PR TITLE
Handle multiple success toasts in petty cash test

### DIFF
--- a/playwright/tests/pettycash.spec.js
+++ b/playwright/tests/pettycash.spec.js
@@ -31,14 +31,14 @@ test.describe.serial('petty cash', () => {
   test('add cash', async () => {
     await pettyCash.open();
     await pettyCash.addCash(testData.pettyCash.add.amount, testData.pettyCash.add.description);
-    await expect(page.locator('.Toastify__toast--success')).toBeVisible();
+    await expect(page.locator('.Toastify__toast--success').last()).toBeVisible();
   });
 
   // Validate withdrawing money from petty cash
   test('withdraw cash', async () => {
     await pettyCash.open();
     await pettyCash.withdrawCash(testData.pettyCash.withdraw.amount, testData.pettyCash.withdraw.description);
-    await expect(page.locator('.Toastify__toast--success')).toBeVisible();
+    await expect(page.locator('.Toastify__toast--success').last()).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure petty cash tests check the most recent success toast

## Testing
- `npm --prefix playwright test staging tests/pettycash.spec.js` *(fails: host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68aaaa203f1083279cdec3e8f4d7e37d