### PR TITLE
fix: handle multiple success toasts in tax code test

### DIFF
--- a/playwright/tests/tax-codes.spec.js
+++ b/playwright/tests/tax-codes.spec.js
@@ -13,7 +13,7 @@ test.skip('add new tax code', async ({ page, context }) => {
   await taxCodes.open();
   await taxCodes.addTaxCode(testData.taxCode.name, testData.taxCode.rate);
 
-  const successToast = page.locator('.Toastify__toast--success');
+  const successToast = page.locator('.Toastify__toast--success').last();
   await expect(successToast).toBeVisible();
   await successToast.waitFor({ state: 'hidden' });
 


### PR DESCRIPTION
## Summary
- handle multiple success toasts by selecting the most recent success message in tax code test

## Testing
- `npm test dev` *(fails: login flow & other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aaacd096f483279ed632b138873130