### PR TITLE
Split settings tests and improve category icon selection

### DIFF
--- a/playwright/pages/settings-page.js
+++ b/playwright/pages/settings-page.js
@@ -71,13 +71,19 @@ class SettingsPage {
     await addBtn.click();
 
     logger.log('Select category icon');
-    // Prefer a dedicated combobox, otherwise fall back to a button labelled
-    // "Icon". Selecting the first option is sufficient for the test.
+    // The icon picker has gone through multiple implementations. Try common
+    // selectors in order of priority and fall back to a generic label lookup.
     let iconDropdown = this.page.locator('#category_icon');
+    if (await iconDropdown.count() === 0) {
+      iconDropdown = this.page.locator('#selectIcon');
+    }
     if (await iconDropdown.count() === 0) {
       iconDropdown = this.page.getByRole('combobox', { name: /icon/i });
       if (await iconDropdown.count() === 0) {
         iconDropdown = this.page.getByRole('button', { name: /icon/i });
+        if (await iconDropdown.count() === 0) {
+          iconDropdown = this.page.getByLabel(/icon/i);
+        }
       }
     }
     await iconDropdown.click();

--- a/playwright/tests/settings.spec.js
+++ b/playwright/tests/settings.spec.js
@@ -3,30 +3,52 @@ const { LoginPage } = require('../pages/login-page');
 const { SettingsPage } = require('../pages/settings-page');
 const testData = require('../testdata');
 
-test('add new tax code and category group in one session', async ({ page, context }) => {
-  const loginPage = new LoginPage(page, context);
-  await loginPage.login(testData.credentials.email, testData.credentials.password);
+// Run tax code and category group tests in a single login session.
+test.describe.serial('settings', () => {
+  /** @type {import('@playwright/test').BrowserContext} */
+  let context;
+  /** @type {import('@playwright/test').Page} */
+  let page;
+  /** @type {LoginPage} */
+  let loginPage;
+  /** @type {SettingsPage} */
+  let settings;
 
-  const settings = new SettingsPage(page);
+  test.beforeAll(async ({ browser }) => {
+    context = await browser.newContext();
+    page = await context.newPage();
+    loginPage = new LoginPage(page, context);
+    await loginPage.login(testData.credentials.email, testData.credentials.password);
+    settings = new SettingsPage(page);
+  });
 
-  // Add tax code
-  await settings.openTaxCodes();
-  await settings.addTaxCode(testData.taxCode.name, testData.taxCode.rate);
-  const taxToast = page.locator('.Toastify__toast--success').last();
-  await expect(taxToast).toBeVisible();
-  await taxToast.waitFor({ state: 'hidden' });
-  const taxRow = settings.findTaxCodeRow(testData.taxCode.name);
-  await expect(taxRow).toContainText(testData.taxCode.name);
-  await expect(taxRow).toContainText(`${testData.taxCode.rate}`);
+  test.afterAll(async () => {
+    if (loginPage) {
+      await loginPage.logout();
+    }
+    if (context) {
+      await context.close();
+    }
+  });
 
-  // Add category group using the same session
-  await settings.openCategories();
-  await settings.addCategoryGroup(testData.categoryGroup.name);
-  const groupToast = page.locator('.Toastify__toast--success').last();
-  await expect(groupToast).toBeVisible();
-  await groupToast.waitFor({ state: 'hidden' });
-  const groupRow = settings.findCategoryGroupRow(testData.categoryGroup.name);
-  await expect(groupRow).toContainText(testData.categoryGroup.name);
+  test('add new tax code', async () => {
+    await settings.openTaxCodes();
+    await settings.addTaxCode(testData.taxCode.name, testData.taxCode.rate);
+    const taxToast = page.locator('.Toastify__toast--success').last();
+    await expect(taxToast).toBeVisible();
+    await taxToast.waitFor({ state: 'hidden' });
+    const taxRow = settings.findTaxCodeRow(testData.taxCode.name);
+    await expect(taxRow).toContainText(testData.taxCode.name);
+    await expect(taxRow).toContainText(`${testData.taxCode.rate}`);
+  });
 
-  await loginPage.logout();
+  test('add new category group', async () => {
+    await settings.openCategories();
+    await settings.addCategoryGroup(testData.categoryGroup.name);
+    const groupToast = page.locator('.Toastify__toast--success').last();
+    await expect(groupToast).toBeVisible();
+    await groupToast.waitFor({ state: 'hidden' });
+    const groupRow = settings.findCategoryGroupRow(testData.categoryGroup.name);
+    await expect(groupRow).toContainText(testData.categoryGroup.name);
+  });
 });


### PR DESCRIPTION
## Summary
- Run settings tests for tax codes and category groups in a single login session using `test.describe.serial`
- Harden category group icon selection by checking multiple selector variants

## Testing
- `npm test dev tests/settings.spec.js` *(fails: browserType.launch executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68abfb67bf84832782854d153ec99e61